### PR TITLE
Minor copy tweaks to code comments

### DIFF
--- a/abletonosc/handler.py
+++ b/abletonosc/handler.py
@@ -49,7 +49,7 @@ class AbletonOSCHandler(Component):
         Start listening for the property named `prop` on the Live object `target`.
         `params` is typically a tuple containing the track/clip index.
 
-        getter can be used for a customer getter when we're accesing native objects
+        getter can be used for a customer getter when we're accessing native objects
         e.g. in view.py we don't return the selected_scene, but the selected_scene index.
 
         Args:

--- a/pythonosc/dispatcher.py
+++ b/pythonosc/dispatcher.py
@@ -81,7 +81,7 @@ class Dispatcher(object):
         Args:
             address: Address to be mapped
             handler: Callback function that will be called as the handler for the given address
-            *args: Fixed arguements that will be passed to the callback function
+            *args: Fixed arguments that will be passed to the callback function
             needs_reply_address: Whether the IP address from which the message originated from shall be passed as
                 an argument to the handler callback
 

--- a/pythonosc/parsing/ntp.py
+++ b/pythonosc/parsing/ntp.py
@@ -6,7 +6,7 @@ import time
 
 from typing import NamedTuple
 
-# 63 zero bits followed by a one in the least signifigant bit is a special
+# 63 zero bits followed by a one in the least significant bit is a special
 # case meaning "immediately."
 IMMEDIATELY = struct.pack('>Q', 1)
 


### PR DESCRIPTION
```
./abletonosc/handler.py:52: accesing ==> accessing
./pythonosc/dispatcher.py:84: arguements ==> arguments
./pythonosc/parsing/ntp.py:9: signifigant ==> significant
```

@ideoforms i hope these are sensible to land into the main repo