### PR TITLE
tab autocomplete, exit/quit to exit

### DIFF
--- a/run-console.py
+++ b/run-console.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #--------------------------------------------------------------------------------
-# Console client for AbletonOSC.
+# Console client for AbletonOSC with tab completion for API paths.
 #
 # Takes OSC commands and parameters, and prints the return value.
 #--------------------------------------------------------------------------------
@@ -13,7 +13,7 @@ import argparse
 
 try:
     import readline
-except:
+except ImportError:
     if sys.platform == "win32":
         print("On Windows, run-console.py requires pyreadline3: pip install pyreadline3")
     else:
@@ -23,15 +23,20 @@ from client import AbletonOSCClient
 
 class LiveAPICompleter:
     def __init__(self, commands):
-        self.commands = commands
+        self.commands = sorted(commands)
+        self.matches = []
 
     def complete(self, text, state):
-        results =  [x for x in self.commands if x.startswith(text)] + [None]
-        return results[state]
-
-words = ["live", "song", "track", "clip", "device", "parameter", "parameters"]
-completer = LiveAPICompleter(words)
-readline.set_completer(completer.complete)
+        if state == 0:
+            # On first trigger, build possible matches.
+            if text:
+                self.matches = [s for s in self.commands if s.startswith(text)]
+            else:
+                self.matches = self.commands[:]
+        try:
+            return self.matches[state]
+        except IndexError:
+            return None
 
 def print_error(address, args):
     print("Received error from Live: %s" % args)
@@ -43,9 +48,101 @@ def main(args):
     client.set_handler("/live/error", print_error)
     client.send_message("/live/api/reload")
 
-    readline.parse_and_bind('tab: complete')
-    print("AbletonOSC command console")
+    # List of OSC API paths for tab completion
+    words = [
+        "/live/application/get/version",
+        "/live/application/get/average_process_usage",
+        "/live/clip/get/notes",
+        "/live/clip/add/notes",
+        "/live/clip/remove/notes",
+        "/live/clips/filter",
+        "/live/clips/unfilter",
+        "/live/clip_slot/duplicate_clip_to",
+        "/live/device/get/num_parameters",
+        "/live/device/get/parameters/name",
+        "/live/device/get/parameters/value",
+        "/live/device/get/parameters/min",
+        "/live/device/get/parameters/max",
+        "/live/device/get/parameters/is_quantized",
+        "/live/device/set/parameters/value",
+        "/live/device/get/parameter/value",
+        "/live/device/get/parameter/value_string",
+        "/live/device/set/parameter/value",
+        "/live/device/get/parameter/name",
+        "/live/device/start_listen/parameter/value",
+        "/live/device/stop_listen/parameter/value",
+        "/live/song/get/num_tracks",
+        "/live/song/get/track_names",
+        "/live/song/get/track_data",
+        "/live/song/export/structure",
+        "/live/song/get/num_scenes",
+        "/live/song/get/scene_names",
+        "/live/song/get/cue_points",
+        "/live/song/cue_point/jump",
+        "/live/song/start_listen/beat",
+        "/live/song/stop_listen/beat",
+        "/live/track/get/send",
+        "/live/track/set/send",
+        "/live/track/delete_clip",
+        "/live/track/get/clips/name",
+        "/live/track/get/clips/length",
+        "/live/track/get/clips/color",
+        "/live/track/get/arrangement_clips/name",
+        "/live/track/get/arrangement_clips/length",
+        "/live/track/get/arrangement_clips/start_time",
+        "/live/track/get/num_devices",
+        "/live/track/get/devices/name",
+        "/live/track/get/devices/type",
+        "/live/track/get/devices/class_name",
+        "/live/track/get/devices/can_have_chains",
+        "/live/track/get/available_output_routing_types",
+        "/live/track/get/available_output_routing_channels",
+        "/live/track/get/output_routing_type",
+        "/live/track/set/output_routing_type",
+        "/live/track/get/output_routing_channel",
+        "/live/track/set/output_routing_channel",
+        "/live/track/get/available_input_routing_types",
+        "/live/track/get/available_input_routing_channels",
+        "/live/track/get/input_routing_type",
+        "/live/track/set/input_routing_type",
+        "/live/track/get/input_routing_channel",
+        "/live/track/set/input_routing_channel",
+        "/live/view/get/selected_scene",
+        "/live/view/get/selected_track",
+        "/live/view/get/selected_clip",
+        "/live/view/get/selected_device",
+        "/live/view/set/selected_scene",
+        "/live/view/set/selected_track",
+        "/live/view/set/selected_clip",
+        "/live/view/set/selected_device",
+        "/live/view/start_listen/selected_scene",
+        "/live/view/start_listen/selected_track",
+        "/live/view/stop_listen/selected_scene",
+        "/live/view/stop_listen/selected_track",
+        "/live/test",
+        "/live/api/reload",
+        "/live/api/get/log_level",
+        "/live/api/set/log_level",
+        # Add more addresses as needed
+    ]
+
+    completer = LiveAPICompleter(words)
+    readline.set_completer(completer.complete)
+
+    # Adjust the completer delimiters to not consider '/' as a word boundary
+    readline.set_completer_delims(readline.get_completer_delims().replace('/', ''))
+
+    # Detect if we're using libedit (macOS default) or GNU readline
+    if 'libedit' in readline.__doc__:
+        # macOS libedit syntax
+        readline.parse_and_bind("bind ^I rl_complete")
+    else:
+        # GNU readline syntax
+        readline.parse_and_bind("tab: complete")
+
+    print("AbletonOSC command console with tab completion")
     print("Usage: /live/osc/command [params]")
+    print("Type 'quit' or 'exit' to exit the console.")
 
     while True:
         try:
@@ -54,21 +151,20 @@ def main(args):
             print()
             break
 
+        # Check if the user wants to exit
+        if command_str.strip().lower() in ('quit', 'exit'):
+            print("Exiting console.")
+            break
+
         if not re.search("\\w", command_str):
-            #--------------------------------------------------------------------------------
             # Command is empty
-            #--------------------------------------------------------------------------------
             continue
         if not re.search("^/", command_str):
-            #--------------------------------------------------------------------------------
             # Command is invalid
-            #--------------------------------------------------------------------------------
             print("OSC address must begin with a slash (/)")
             continue
 
-        #--------------------------------------------------------------------------------
         # Parse command-line, with support for quoted strings
-        #--------------------------------------------------------------------------------
         command, *params_str = shlex.split(command_str)
         params = []
         for part in params_str:
@@ -90,7 +186,7 @@ def main(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Console client for AbletonOSC. Takes OSC commands and parameters, and prints the return value.")
     parser.add_argument("--hostname", type=str, default="127.0.0.1")
-    parser.add_argument("--port", type=str, default=11000)
+    parser.add_argument("--port", type=int, default=11000)
     parser.add_argument("--verbose", "-v", action="store_true", help="verbose mode: prints all OSC messages")
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
@ideoforms 
as per your ticket https://github.com/ideoforms/AbletonOSC/issues/36

here's two alterations:
1. Exit / Quit will now cleanly exit the run-console.py
2. Tab will attempt to autocomplete what you've written in, and show you the handlers that are currently there.

![run-console autocomplete](https://github.com/user-attachments/assets/42c18854-2e3c-4eda-9dc0-0ddb90fab822)

the list is static generated, not dynamically generated - by just fetching all the add_handlers from all the code.