### PR TITLE
Add 'play_selection' to song methods

### DIFF
--- a/abletonosc/song.py
+++ b/abletonosc/song.py
@@ -33,6 +33,7 @@ class SongHandler(AbletonOSCHandler):
             "jump_to_prev_cue",
             "jump_to_next_cue",
             "redo",
+            "play_selection",
             "start_playing",
             "stop_all_clips",
             "stop_playing",

--- a/tests/test_song.py
+++ b/tests/test_song.py
@@ -28,6 +28,17 @@ def test_song_beat(client):
     client.send_message("/live/song/stop_playing")
     client.send_message("/live/song/stop_listen/beat")
     wait_one_tick()
+    client.send_message("/live/song/stop_playing")
+    wait_one_tick()
+    client.send_message("/live/song/start_listen/beat")
+    # play_selection does the same thing as start_playing if there is no selection,
+    # and there is no way to modify the selection via the API.
+    # This test only asserts that the method works, not the additional expected functionality.
+    client.send_message("/live/song/play_selection")
+    wait_one_tick()
+    wait_one_tick()
+    assert client.await_message("/live/song/get/beat", timeout=1.0) == (1,)
+    assert client.await_message("/live/song/get/beat", timeout=1.0) == (2,)
 
 def test_song_stop_all_clips(client):
     client.send_message("/live/clip_slot/create_clip", (0, 0, 4))


### PR DESCRIPTION
Adds missing [`Live.Song.play_selection`](https://docs.cycling74.com/legacy/max8/vignettes/live_object_model#:~:text=play_selection) method.

I added tests, however I'm not aware of how to run the test suite (not a Python dev 😅).