### PR TITLE
Adds handler for /live/api/show_message

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ same IP as the originating message. When querying properties, OSC wildcard patte
 | /live/api/reload              |              |                              | Initiates a live reload of the AbletonOSC server code. Used in development only.         |
 | /live/api/get/log_level       |              | log_level                    | Returns the current log level. Default is `info`.                                        |
 | /live/api/set/log_level       | log_level    |                              | Set the log level, which can be one of: `debug`, `info`, `warning`, `error`, `critical`. |
+| /live/api/show_message        | message      |                              | Show a message in Live's status bar                                                      |
 
 ### Application status messages
 

--- a/manager.py
+++ b/manager.py
@@ -77,11 +77,14 @@ class Manager(ControlSurface):
             assert log_level in ("debug", "info", "warning", "error", "critical")
             self.log_level = log_level
             self.log_file_handler.setLevel(self.log_level.upper())
+        def show_message_callback(params):
+            self.show_message(params[0])
 
         self.osc_server.add_handler("/live/test", test_callback)
         self.osc_server.add_handler("/live/api/reload", reload_callback)
         self.osc_server.add_handler("/live/api/get/log_level", get_log_level_callback)
         self.osc_server.add_handler("/live/api/set/log_level", set_log_level_callback)
+        self.osc_server.add_handler("/live/api/show_message", show_message_callback)
 
         with self.component_guard():
             self.handlers = [


### PR DESCRIPTION
Enables passing messages to `ControlSurface.show_message` via OSC to display information in Live’s status bar.