### PR TITLE
Add key signature properties

### DIFF
--- a/abletonosc/song.py
+++ b/abletonosc/song.py
@@ -62,6 +62,8 @@ class SongHandler(AbletonOSCHandler):
             "punch_in",
             "punch_out",
             "record_mode",
+            "root_note",
+            "scale_name",
             "session_record",
             "signature_denominator",
             "signature_numerator",


### PR DESCRIPTION
Adds support for root_note and scale_name properties to enable key signature control via OSC.

## Changes
- Added root_note to properties_rw (enables /live/song/get/root_note and /live/song/set/root_note)  
- Added scale_name to properties_rw (enables /live/song/get/scale_name and /live/song/set/scale_name)

## Usage
```
/live/song/get/root_note     # Returns 0-11 (C=0, C#=1, etc.)
/live/song/set/root_note 9   # Sets to A
/live/song/get/scale_name    # Returns "Minor", "Major", etc.
/live/song/set/scale_name Minor
```

Uses standard AbletonOSC property handling - no custom handlers needed.