### PR TITLE
Add "create_audio_clip" and  "create_midi_clip" handler for tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ To query the properties of multiple tracks, see [Song: Properties of cue points,
 
 ### Track methods
 
-| Address                       | Query params                      | Response params | Description              |
-|:------------------------------|:----------------------------------|:----------------|:-------------------------|
-| /live/track/stop_all_clips    | track_id                          |                 | Stop all clips on track  |
-| /live/track/create_audio_clip | track_id, file_path, position     |                 | Adds audio clip to track |
-| /live/track/create_midi_clip  | track_id, position, length        |                 | Adds midi clip to track  |
+| Address                       | Query params                      | Response params | Description                                                                 |
+|:------------------------------|:----------------------------------|:----------------|:----------------------------------------------------------------------------|
+| /live/track/stop_all_clips    | track_id                          |                 | Stop all clips on track                                                     |
+| /live/track/create_audio_clip | track_id, file_path, position     |                 | Add sample at absolute file path as audio clip to track in arrangement view |
+| /live/track/create_midi_clip  | track_id, position, length        |                 | Add midi clip to track in arrangement view                                  |
 
 ### Track properties
 

--- a/README.md
+++ b/README.md
@@ -231,9 +231,11 @@ To query the properties of multiple tracks, see [Song: Properties of cue points,
 
 ### Track methods
 
-| Address                    | Query params | Response params | Description             |
-|:---------------------------|:-------------|:----------------|:------------------------|
-| /live/track/stop_all_clips | track_id     |                 | Stop all clips on track |
+| Address                       | Query params                      | Response params | Description              |
+|:------------------------------|:----------------------------------|:----------------|:-------------------------|
+| /live/track/stop_all_clips    | track_id                          |                 | Stop all clips on track  |
+| /live/track/create_audio_clip | track_id, file_path, position     |                 | Adds audio clip to track |
+| /live/track/create_midi_clip  | track_id, position, length        |                 | Adds midi clip to track  |
 
 ### Track properties
 

--- a/abletonosc/track.py
+++ b/abletonosc/track.py
@@ -31,7 +31,9 @@ class TrackHandler(AbletonOSCHandler):
 
         methods = [
             "delete_device",
-            "stop_all_clips"
+            "stop_all_clips",
+            "create_audio_clip",
+            "create_midi_clip",
         ]
         properties_r = [
             "can_be_armed",


### PR DESCRIPTION
## Description

Supposedly since version 12.0.5, Ableton exposes functions for creating audio & midi clips on tracks directly. LOM documentation indeed mentions [`track.create_audio_clip`](https://docs.cycling74.com/apiref/lom/track/#create_audio_clip) and [`track.create_midi_clip`](https://docs.cycling74.com/apiref/lom/track/#create_midi_clip). I saw some [chatter](https://github.com/ideoforms/AbletonOSC/issues/123#issuecomment-2027970969) about this functionality and wanted to propose a very simple implementation.

potentially resolves #123 

## Usage
With these changes, adding clips is trivial. 
```
/live/track/create_audio_clip 1 "C:/test.wav" 0
/live/track/create_midi_clip 2 0 10
```

## Checklist

- [x] The title is descriptive and summarises the new changes
- [x] The code and any comments are consistent with the current code style
- [x] For any new or modified API endpoints, I have added appropriate documentation to [README.md](/README.md)
 - [ ]  <del>For any new or modified API endpoints, I have added [unit tests](/tests/) covering the new functionality </del>
- [ ] <del>I have verified that all unit tests pass (see [CONTRIBUTING.md](/CONTRIBUTING.md) for guidance)</del>

> The `create_audio_track` requires an absolute path to an audio file which adds complexity to writing tests.
