### PR TITLE
fix: duplicate_clip_to_arrangement passes clip instead of clip_slot

### DIFF
--- a/abletonosc/track.py
+++ b/abletonosc/track.py
@@ -136,6 +136,19 @@ class TrackHandler(AbletonOSCHandler):
         self.osc_server.add_handler("/live/track/get/arrangement_clips/length", create_track_callback(track_get_arrangement_clip_lengths))
         self.osc_server.add_handler("/live/track/get/arrangement_clips/start_time", create_track_callback(track_get_arrangement_clip_start_times))
 
+        def track_duplicate_clip_to_arrangement(track, params):
+            """
+            Duplicate a session clip to arrangement view at a specific time.
+            params: (clip_slot_index, time_in_beats)
+            """
+            clip_slot_index = int(params[0])
+            time = float(params[1])
+            clip_slot = track.clip_slots[clip_slot_index]
+            if clip_slot.clip:
+                track.duplicate_clip_to_arrangement(clip_slot.clip, time)
+
+        self.osc_server.add_handler("/live/track/duplicate_clip_to_arrangement", create_track_callback(track_duplicate_clip_to_arrangement))
+
         def track_get_num_devices(track, _):
             return len(track.devices),
 


### PR DESCRIPTION
## Summary

- Fix `duplicate_clip_to_arrangement` to pass `clip_slot.clip` instead of `clip_slot`
- Add null check to prevent errors when clip_slot is empty

## Problem

The `Track.duplicate_clip_to_arrangement()` method in Ableton's Python API expects a `Clip` object, not a `ClipSlot` object:

```
Track.duplicate_clip_to_arrangement(clip, destination_time)
```

The current implementation passes the `clip_slot` directly, which causes a `Boost.Python.ArgumentError`:

```
Boost.Python.ArgumentError: Python argument types in
    Track.duplicate_clip_to_arrangement(Track, ClipSlot, float)
did not match C++ signature:
    duplicate_clip_to_arrangement(class TTrackPyHandle self, class TPyHandle<class AClip> clip, double destination_time)
```

## Solution

Changed line 147 in `track.py` from:
```python
track.duplicate_clip_to_arrangement(clip_slot, time)
```

To:
```python
if clip_slot.clip:
    track.duplicate_clip_to_arrangement(clip_slot.clip, time)
```

## Test plan

- [x] Verified fix works in Ableton Live 12.3.2
- [x] Clips are successfully duplicated from session view to arrangement view at specified beat positions
- [x] Empty clip slots are handled gracefully (no error, just no-op)

🤖 Generated with [Claude Code](https://claude.ai/code)