### PR TITLE
Add create_audio_clip for clip slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ A Clip Slot represents a container for a clip. It is used to create and delete c
 |:------------------------------------|:---------------------------------------------------------------|:-----------------------------------------|:------------------------------------------------|
 | /live/clip_slot/fire                | track_index, clip_index                                        |                                          | Fire play/pause of the specified clip slot      |
 | /live/clip_slot/create_clip         | track_index, clip_index, length                                |                                          | Create a clip in the slot                       |
+| /live/clip_slot/create_audio_clip   | track_index, clip_index, file_path                             |                                          | Create an audio clip from file in the slot      |
 | /live/clip_slot/delete_clip         | track_index, clip_index                                        |                                          | Delete the clip in the slot                     |
 | /live/clip_slot/get/has_clip        | track_index, clip_index                                        | track_index, clip_index, has_clip        | Query whether the slot has a clip               |
 | /live/clip_slot/get/has_stop_button | track_index, clip_index                                        | track_index, clip_index, has_stop_button | Query whether the slot has a stop button        |

--- a/abletonosc/clip_slot.py
+++ b/abletonosc/clip_slot.py
@@ -28,6 +28,7 @@ class ClipSlotHandler(AbletonOSCHandler):
             "fire",
             "stop",
             "create_clip",
+            "create_audio_clip",
             "delete_clip"
         ]
         properties_r = [


### PR DESCRIPTION
## Description

Similar to [PR-168](https://github.com/ideoforms/AbletonOSC/pull/168), this exposes the new capability for adding audio clips to clip_slots in session view: [`clip_slot.create_audio_clip`](https://docs.cycling74.com/apiref/lom/track/#create_audio_clip)

This should also help with [Issue #123](https://github.com/ideoforms/AbletonOSC/issues/123)

## Usage
```
# Create audio clip in session view at track 2, clip slot 4
/live/clip_slot/create_audio_clip 2 4 "C:/test.wav"
```

## Checklist

- [X] The title is descriptive and summarises the new changes
- [X] The code and any comments are consistent with the current code style
- [X] For any new or modified API endpoints, I have added appropriate documentation to [README.md](/README.md)
- [x] ~For any new or modified API endpoints, I have added [unit tests](/tests/) covering the new functionality~
- [x] ~I have verified that all unit tests pass (see [CONTRIBUTING.md](/CONTRIBUTING.md) for guidance)~

> No unit tests added as it requires a valid audio file path.
