### PR TITLE
Add Master and Return Track Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ for [Live Object Model - Song](https://docs.cycling74.com/max8/vignettes/live_ob
 | /live/song/get/cue_points  |              | name, time, ...        | Query a list of the song's cue points                                       |
 | /live/song/get/num_scenes  |              | num_scenes             | Query the number of scenes                                                  |
 | /live/song/get/num_tracks  |              | num_tracks             | Query the number of tracks                                                  |
-| /live/song/get/track_names |              | [index_min, index_max] | Query track names (optionally, over a given range)                          |
-| /live/song/get/track_data  |              | [various]              | Query bulk properties of multiple tracks/clips. See below for further info. |
+| /live/song/get/track_names |              | [index_min, index_max] | Query track names (optionally, over a given range); with no params or `index_max=-1`, includes master and return tracks |
+| /live/song/get/track_data  |              | [various]              | Query bulk properties of multiple tracks/clips (see below); with `track_index_max=-1`, includes master and return tracks |
 
 
 #### Querying track/clip data in bulk with /live/song/get/track_data
@@ -239,6 +239,7 @@ To query the properties of multiple tracks, see [Song: Properties of cue points,
 
  - Changes for any Track property can be listened for by calling `/live/track/start_listen/<property> <track_index>`
  - Responses will be sent to `/live/track/get/<property>`, with parameters `<track_index> <property_value>`
+ - `track_id` can be a numeric index, `"master"` (or `"main"`), or a return track prefix (e.g. `"A"`, `"B"`). The wildcard `*` includes all regular tracks, master, and return tracks.
 
 #### Getters
 
@@ -478,6 +479,7 @@ Represents an instrument or effect.
 ### Device properties
 
 - Changes for any Parameter property can be listened for by calling `/live/device/start_listen/parameter/value <track_index> <device index> <parameter_index>`
+- `track_id` can be a numeric index, `"master"` (or `"main"`), or a return track prefix (e.g. `"A"`, `"B"`).
 
 | Address                                  | Query params                             | Response params                          | Description                                                                             |
 |:-----------------------------------------|:-----------------------------------------|:-----------------------------------------|:----------------------------------------------------------------------------------------|

--- a/abletonosc/device.py
+++ b/abletonosc/device.py
@@ -9,15 +9,23 @@ class DeviceHandler(AbletonOSCHandler):
     def init_api(self):
         def create_device_callback(func, *args, include_ids: bool = False):
             def device_callback(params: Tuple[Any]):
-                track_index, device_index = int(params[0]), int(params[1])
-                device = self.song.tracks[track_index].devices[device_index]
-                if (include_ids):
+                track_param = params[0]
+                device_index = int(params[1])
+
+                result = self._resolve_track(track_param)
+                if result is None:
+                    return None
+                track, track_identifier = result
+
+                device = track.devices[device_index]
+
+                if include_ids:
                     rv = func(device, *args, params[0:])
                 else:
                     rv = func(device, *args, params[2:])
 
                 if rv is not None:
-                    return (track_index, device_index, *rv)
+                    return (track_identifier, device_index, *rv)
 
             return device_callback
 

--- a/abletonosc/handler.py
+++ b/abletonosc/handler.py
@@ -21,6 +21,36 @@ class AbletonOSCHandler(Component):
     def clear_api(self):
         self._clear_listeners()
 
+    def _resolve_track(self, track_param):
+        """
+        Resolve a track parameter to a (track_obj, track_identifier) tuple.
+        
+        Args:
+            track_param: Can be:
+                - An int or numeric value: index into self.song.tracks
+                - "master" or "main" (case-insensitive): self.song.master_track
+                - A return track prefix (e.g. "A"): matched against self.song.return_tracks names
+        
+        Returns:
+            Tuple of (track_obj, track_identifier) or None if the identifier is invalid.
+        """
+        if isinstance(track_param, str):
+            if track_param.lower() in ("master", "main"):
+                return (self.song.master_track, "master")
+            else:
+                for idx, rt in enumerate(self.song.return_tracks):
+                    if rt.name.startswith(track_param + "-"):
+                        return (self.song.return_tracks[idx], track_param)
+                self.logger.error(
+                    "AbletonOSC: Invalid track identifier '%s'. "
+                    "Must be a numeric track index, 'master'/'main', "
+                    "or one of the return track prefixes." % track_param
+                )
+                return None
+        else:
+            track_index = int(track_param)
+            return (self.song.tracks[track_index], track_index)
+
     #--------------------------------------------------------------------------------
     # Generic callbacks
     #--------------------------------------------------------------------------------

--- a/abletonosc/song.py
+++ b/abletonosc/song.py
@@ -100,7 +100,6 @@ class SongHandler(AbletonOSCHandler):
 
         def song_get_track_names(params):
             if len(params) == 0:
-                # No params: return all regular tracks + master + returns
                 track_names = [track.name for track in self.song.tracks]
                 track_names.append(self.song.master_track.name)
                 track_names.extend([rt.name for rt in self.song.return_tracks])
@@ -113,7 +112,6 @@ class SongHandler(AbletonOSCHandler):
                     track_names.extend([rt.name for rt in self.song.return_tracks])
                     return tuple(track_names)
                 else:
-                    # Explicit range: regular tracks only
                     return tuple(self.song.tracks[index].name for index in range(track_index_min, track_index_max))
         self.osc_server.add_handler("/live/song/get/track_names", song_get_track_names)
 

--- a/abletonosc/song.py
+++ b/abletonosc/song.py
@@ -100,12 +100,21 @@ class SongHandler(AbletonOSCHandler):
 
         def song_get_track_names(params):
             if len(params) == 0:
-                track_index_min, track_index_max = 0, len(self.song.tracks)
+                # No params: return all regular tracks + master + returns
+                track_names = [track.name for track in self.song.tracks]
+                track_names.append(self.song.master_track.name)
+                track_names.extend([rt.name for rt in self.song.return_tracks])
+                return tuple(track_names)
             else:
                 track_index_min, track_index_max = params
                 if track_index_max == -1:
-                    track_index_max = len(self.song.tracks)
-            return tuple(self.song.tracks[index].name for index in range(track_index_min, track_index_max))
+                    track_names = [self.song.tracks[index].name for index in range(track_index_min, len(self.song.tracks))]
+                    track_names.append(self.song.master_track.name)
+                    track_names.extend([rt.name for rt in self.song.return_tracks])
+                    return tuple(track_names)
+                else:
+                    # Explicit range: regular tracks only
+                    return tuple(self.song.tracks[index].name for index in range(track_index_min, track_index_max))
         self.osc_server.add_handler("/live/song/get/track_names", song_get_track_names)
 
         def song_get_track_data(params):
@@ -125,13 +134,25 @@ class SongHandler(AbletonOSCHandler):
             track_index_min, track_index_max, *properties = params
             track_index_min = int(track_index_min)
             track_index_max = int(track_index_max)
-            self.logger.info("Getting track data: %s (tracks %d..%d)" %
-                             (properties, track_index_min, track_index_max))
+            
+            tracks_to_process = []
+            include_master_returns = (track_index_max == -1)
+            
             if track_index_max == -1:
                 track_index_max = len(self.song.tracks)
-            rv = []
+            
             for track_index in range(track_index_min, track_index_max):
-                track = self.song.tracks[track_index]
+                tracks_to_process.append(self.song.tracks[track_index])
+            
+            if include_master_returns:
+                tracks_to_process.append(self.song.master_track)
+                tracks_to_process.extend(self.song.return_tracks)
+            
+            self.logger.info("Getting track data: %s (tracks %d..%d, include_master_returns=%s)" %
+                             (properties, track_index_min, track_index_max, include_master_returns))
+            
+            rv = []
+            for track in tracks_to_process:
                 for prop in properties:
                     obj, property_name = prop.split(".")
                     if obj == "track":
@@ -146,24 +167,51 @@ class SongHandler(AbletonOSCHandler):
                                 value = list(self.song.tracks).index(value)
                         rv.append(value)
                     elif obj == "clip":
-                        for clip_slot in track.clip_slots:
-                            if clip_slot.clip is not None:
-                                rv.append(getattr(clip_slot.clip, property_name))
-                            else:
-                                rv.append(None)
+                        if hasattr(track, 'clip_slots'):
+                            for clip_slot in track.clip_slots:
+                                if clip_slot.clip is not None:
+                                    rv.append(getattr(clip_slot.clip, property_name))
+                                else:
+                                    rv.append(None)
+                        else:
+                            rv.append(None)
                     elif obj == "clip_slot":
-                        for clip_slot in track.clip_slots:
-                            rv.append(getattr(clip_slot, property_name))
+                        if hasattr(track, 'clip_slots'):
+                            for clip_slot in track.clip_slots:
+                                rv.append(getattr(clip_slot, property_name))
+                        else:
+                            rv.append(None)
                     elif obj == "device":
                         for device in track.devices:
                             rv.append(getattr(device, property_name))
                     else:
-                        self.logger.error("Unknown object identifier in get/track_data: %s" % obj)
+                        self.logger.error("AbletonOSC: Unknown object identifier in get/track_data: %s" % obj)
             return tuple(rv)
         self.osc_server.add_handler("/live/song/get/track_data", song_get_track_data)
 
 
         def song_export_structure(params):
+            def extract_device_data(devices):
+                """Helper to extract device data for any track type."""
+                device_list = []
+                for device_index, device in enumerate(devices):
+                    device_data = {
+                        "class_name": device.class_name,
+                        "type": device.type,
+                        "name": device.name,
+                        "parameters": []
+                    }
+                    for parameter in device.parameters:
+                        device_data["parameters"].append({
+                            "name": parameter.name,
+                            "value": parameter.value,
+                            "min": parameter.min,
+                            "max": parameter.max,
+                            "is_quantized": parameter.is_quantized,
+                        })
+                    device_list.append(device_data)
+                return device_list
+            
             tracks = []
             for track_index, track in enumerate(self.song.tracks):
                 group_track = None
@@ -186,26 +234,27 @@ class SongHandler(AbletonOSCHandler):
                         }
                         track_data["clips"].append(clip_data)
 
-                for device_index, device in enumerate(track.devices):
-                    device_data = {
-                        "class_name": device.class_name,
-                        "type": device.type,
-                        "name": device.name,
-                        "parameters": []
-                    }
-                    for parameter in device.parameters:
-                        device_data["parameters"].append({
-                            "name": parameter.name,
-                            "value": parameter.value,
-                            "min": parameter.min,
-                            "max": parameter.max,
-                            "is_quantized": parameter.is_quantized,
-                        })
-                    track_data["devices"].append(device_data)
-
+                track_data["devices"] = extract_device_data(track.devices)
                 tracks.append(track_data)
+            
+            master_track = {
+                "name": self.song.master_track.name,
+                "devices": extract_device_data(self.song.master_track.devices)
+            }
+            
+            return_tracks = []
+            for rt_index, rt in enumerate(self.song.return_tracks):
+                return_track_data = {
+                    "index": rt_index,
+                    "name": rt.name,
+                    "devices": extract_device_data(rt.devices)
+                }
+                return_tracks.append(return_track_data)
+            
             song = {
-                "tracks": tracks
+                "tracks": tracks,
+                "master_track": master_track,
+                "return_tracks": return_tracks
             }
 
             if sys.platform == "darwin":

--- a/abletonosc/track.py
+++ b/abletonosc/track.py
@@ -11,21 +11,24 @@ class TrackHandler(AbletonOSCHandler):
         def create_track_callback(func: Callable,
                                   *args,
                                   include_track_id: bool = False):
-            def track_callback(params: Tuple[Any]):
+            def track_callback(params: Tuple[Any]):                
                 if params[0] == "*":
-                    track_indices = list(range(len(self.song.tracks)))
+                    tracks_to_process = [(self.song.tracks[i], i) for i in range(len(self.song.tracks))]
+                    tracks_to_process.append((self.song.master_track, "master"))
+                    tracks_to_process.extend([(rt, rt.name) for rt in self.song.return_tracks])
                 else:
-                    track_indices = [int(params[0])]
-
-                for track_index in track_indices:
-                    track = self.song.tracks[track_index]
+                    result = self._resolve_track(params[0])
+                    if result is None:
+                        return None
+                
+                for track_obj, track_identifier in result:
                     if include_track_id:
-                        rv = func(track, *args, tuple([track_index] + params[1:]))
+                        rv = func(track_obj, *args, tuple([track_identifier] + params[1:]))
                     else:
-                        rv = func(track, *args, tuple(params[1:]))
-
+                        rv = func(track_obj, *args, tuple(params[1:]))
+                    
                     if rv is not None:
-                        return (track_index, *rv)
+                        return (track_identifier, *rv)
 
             return track_callback
 

--- a/abletonosc/track.py
+++ b/abletonosc/track.py
@@ -17,9 +17,10 @@ class TrackHandler(AbletonOSCHandler):
                     tracks_to_process.append((self.song.master_track, "master"))
                     tracks_to_process.extend([(rt, rt.name) for rt in self.song.return_tracks])
                 else:
-                    tracks_to_process = self._resolve_track(params[0])
-                    if tracks_to_process is None:
+                    resolved = self._resolve_track(params[0])
+                    if resolved is None:
                         return None
+                    tracks_to_process = [resolved]
                 
                 for track_obj, track_identifier in tracks_to_process:
                     if include_track_id:

--- a/abletonosc/track.py
+++ b/abletonosc/track.py
@@ -17,11 +17,11 @@ class TrackHandler(AbletonOSCHandler):
                     tracks_to_process.append((self.song.master_track, "master"))
                     tracks_to_process.extend([(rt, rt.name) for rt in self.song.return_tracks])
                 else:
-                    result = self._resolve_track(params[0])
-                    if result is None:
+                    tracks_to_process = self._resolve_track(params[0])
+                    if tracks_to_process is None:
                         return None
                 
-                for track_obj, track_identifier in result:
+                for track_obj, track_identifier in tracks_to_process:
                     if include_track_id:
                         rv = func(track_obj, *args, tuple([track_identifier] + params[1:]))
                     else:

--- a/tests/test_song.py
+++ b/tests/test_song.py
@@ -197,3 +197,71 @@ def test_song_undo_redo(client):
     wait_one_tick()
     assert client.query("/live/song/get/num_scenes") == (9,)
     client.send_message("/live/song/delete_scene", [8])
+
+#--------------------------------------------------------------------------------
+# Test song - track names with master/return tracks
+#--------------------------------------------------------------------------------
+
+def test_song_get_track_names_no_params_includes_main_and_returns(client):
+    """No params: should return all regular tracks + master + return tracks."""
+    result = client.query("/live/song/get/track_names")
+    # 4 regular tracks + Master + at least one return track (A)
+    assert len(result) > 4
+    # Master track name should be present
+    assert "Main" in result
+
+def test_song_get_track_names_open_ended_includes_main_and_returns(client):
+    """Range ending in -1: should include master and return tracks."""
+    result = client.query("/live/song/get/track_names", (0, -1))
+    assert "Main" in result
+
+def test_song_get_track_names_explicit_range_excludes_main_and_returns(client):
+    """Explicit numeric range: should include only regular tracks, no master/returns."""
+    result = client.query("/live/song/get/track_names", (0, 2))
+    assert len(result) == 2
+    assert "Main" not in result
+
+def test_song_get_track_names_partial_open_ended_includes_main_and_returns(client):
+    """Range starting mid-list, ending at -1: includes remaining regular tracks + master + returns."""
+    result = client.query("/live/song/get/track_names", (2, -1))
+    assert "Main" in result
+
+#--------------------------------------------------------------------------------
+# Test song - track data with master/return tracks
+#--------------------------------------------------------------------------------
+
+def test_song_get_track_data_open_ended_includes_main_and_returns(client):
+    """track_data with -1 range should include master and return track names."""
+    result = client.query("/live/song/get/track_data", (0, -1, "track.name"))
+    assert result is not None
+    assert "Main" in result
+
+def test_song_get_track_data_explicit_range_excludes_main(client):
+    """track_data with explicit range should not include master track name."""
+    result = client.query("/live/song/get/track_data", (0, 2, "track.name"))
+    assert result is not None
+    assert "Main" not in result
+
+def test_song_get_track_data_clip_property_with_master_does_not_crash(client):
+    """
+    Querying a clip property across the full range (including master/return tracks
+    that have no clip_slots) should not raise an error - master/returns return None.
+    """
+    result = client.query("/live/song/get/track_data", (0, -1, "clip.name"))
+    assert result is not None
+
+def test_song_get_track_data_clip_slot_property_with_master_does_not_crash(client):
+    """
+    Querying a clip_slot property across the full range should not raise for
+    master/return tracks that have no clip_slots.
+    """
+    result = client.query("/live/song/get/track_data", (0, -1, "clip_slot.has_clip"))
+    assert result is not None
+
+def test_song_get_track_data_device_property_with_master(client):
+    """
+    Querying a device property across the full range (including master/return tracks)
+    should not crash. Master/return tracks with no devices yield an empty contribution.
+    """
+    result = client.query("/live/song/get/track_data", (0, -1, "device.name"))
+    assert result is not None

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -98,13 +98,6 @@ def test_track_master_volume(client):
     client.send_message("/live/track/set/volume", ("master", 1.0))
     wait_one_tick()
 
-def test_track_master_panning(client):
-    client.send_message("/live/track/set/panning", ("master", 0.25))
-    wait_one_tick()
-    assert client.query("/live/track/get/panning", ("master",)) == ("master", 0.25)
-    client.send_message("/live/track/set/panning", ("master", 0.0))
-    wait_one_tick()
-
 def test_track_master_num_devices(client):
     result = client.query("/live/track/get/num_devices", ("master",))
     assert result[0] == "master"
@@ -126,19 +119,6 @@ def test_track_return_volume(client):
     client.send_message("/live/track/set/volume", ("A", 1.0))
     wait_one_tick()
 
-def test_track_return_panning(client):
-    client.send_message("/live/track/set/panning", ("A", 0.25))
-    wait_one_tick()
-    assert client.query("/live/track/get/panning", ("A",)) == ("A", 0.25)
-    client.send_message("/live/track/set/panning", ("A", 0.0))
-    wait_one_tick()
-
-def test_track_return_mute(client):
-    client.send_message("/live/track/set/mute", ("A", 1))
-    wait_one_tick()
-    assert client.query("/live/track/get/mute", ("A",)) == ("A", True)
-    client.send_message("/live/track/set/mute", ("A", 0))
-    wait_one_tick()
 
 def test_track_return_num_devices(client):
     result = client.query("/live/track/get/num_devices", ("A",))

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -76,6 +76,108 @@ def test_track_devices(client):
     assert client.query("/live/track/get/num_devices", (track_id,)) == (track_id, 0,)
 
 #--------------------------------------------------------------------------------
+# Test track properties - master track
+#--------------------------------------------------------------------------------
+
+def test_track_master_get_name(client):
+    result = client.query("/live/track/get/name", ("master",))
+    assert result[0] == "master"
+    assert result[1] == "Main"
+
+def test_track_main_alias(client):
+    result_master = client.query("/live/track/get/name", ("master",))
+    result_main = client.query("/live/track/get/name", ("main",))
+    assert result_master[0] == "master"
+    assert result_main[0] == "master"
+    assert result_master[1] == result_main[1]
+
+def test_track_master_volume(client):
+    client.send_message("/live/track/set/volume", ("master", 0.5))
+    wait_one_tick()
+    assert client.query("/live/track/get/volume", ("master",)) == ("master", 0.5)
+    client.send_message("/live/track/set/volume", ("master", 1.0))
+    wait_one_tick()
+
+def test_track_master_panning(client):
+    client.send_message("/live/track/set/panning", ("master", 0.25))
+    wait_one_tick()
+    assert client.query("/live/track/get/panning", ("master",)) == ("master", 0.25)
+    client.send_message("/live/track/set/panning", ("master", 0.0))
+    wait_one_tick()
+
+def test_track_master_num_devices(client):
+    result = client.query("/live/track/get/num_devices", ("master",))
+    assert result[0] == "master"
+    assert isinstance(result[1], int)
+
+#--------------------------------------------------------------------------------
+# Test track properties - return tracks
+#--------------------------------------------------------------------------------
+
+def test_track_return_get_name(client):
+    result = client.query("/live/track/get/name", ("A",))
+    assert result is not None
+    assert result[0] == "A"
+
+def test_track_return_volume(client):
+    client.send_message("/live/track/set/volume", ("A", 0.5))
+    wait_one_tick()
+    assert client.query("/live/track/get/volume", ("A",)) == ("A", 0.5)
+    client.send_message("/live/track/set/volume", ("A", 1.0))
+    wait_one_tick()
+
+def test_track_return_panning(client):
+    client.send_message("/live/track/set/panning", ("A", 0.25))
+    wait_one_tick()
+    assert client.query("/live/track/get/panning", ("A",)) == ("A", 0.25)
+    client.send_message("/live/track/set/panning", ("A", 0.0))
+    wait_one_tick()
+
+def test_track_return_mute(client):
+    client.send_message("/live/track/set/mute", ("A", 1))
+    wait_one_tick()
+    assert client.query("/live/track/get/mute", ("A",)) == ("A", True)
+    client.send_message("/live/track/set/mute", ("A", 0))
+    wait_one_tick()
+
+def test_track_return_num_devices(client):
+    result = client.query("/live/track/get/num_devices", ("A",))
+    assert result[0] == "A"
+    assert isinstance(result[1], int)
+
+#--------------------------------------------------------------------------------
+# Test that numeric indices still work (regression)
+#--------------------------------------------------------------------------------
+
+def test_track_numeric_index_regression(client):
+    result = client.query("/live/track/get/name", (0,))
+    assert result[0] == 0
+    assert isinstance(result[1], str)
+
+def test_track_numeric_index_volume_regression(client):
+    client.send_message("/live/track/set/volume", (2, 0.5))
+    wait_one_tick()
+    assert client.query("/live/track/get/volume", (2,)) == (2, 0.5)
+    client.send_message("/live/track/set/volume", (2, 1.0))
+    wait_one_tick()
+
+#--------------------------------------------------------------------------------
+# Test listeners - master track
+#--------------------------------------------------------------------------------
+
+def test_track_listen_master_volume(client):
+    client.send_message("/live/track/set/volume", ("master", 1.0))
+    client.send_message("/live/track/start_listen/volume", ("master",))
+    assert client.await_message("/live/track/get/volume", TICK_DURATION * 2) == ("master", 1.0)
+
+    client.send_message("/live/track/set/volume", ("master", 0.5))
+    assert client.await_message("/live/track/get/volume", TICK_DURATION * 2) == ("master", 0.5)
+
+    client.send_message("/live/track/stop_listen/volume", ("master",))
+    client.send_message("/live/track/set/volume", ("master", 1.0))
+    wait_one_tick()
+
+#--------------------------------------------------------------------------------
 # Test track properties - listeners
 #--------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Add Master and Return Track Support

This PR adds support for accessing master and return tracks throughout the AbletonOSC API, independent of the number of tracks in the set. Previously, only regular Audio/MIDI tracks could be accessed via the Track, Device, and Song APIs. Now, master and return tracks can be accessed using string identifiers or are automatically included when enumerating "all" tracks.

This PR closes #47 and reimplements #84. Referencing that discussion, a goal with this PR was to keep a similar namespace to what's already implemented by the API for maximum legibility and backward compatibility, as well as to enable querying master and send/return tracks independent of the number of tracks in the set. More details about the specific implementation below.

## Motivation

- Master and return tracks are essential parts of any Ableton Live set, but were previously inaccessible via the OSC API
- Users can now query device parameters, meters, and other properties on master and return tracks
- Bulk operations (wildcards, song data exports) now include all track types

## Changes

### 1. Added Shared Track Resolution Helper

**File**: `abletonosc/handler.py`

Created a reusable `_resolve_track()` method on `AbletonOSCHandler` that resolves track parameters to track objects:

- **Numeric index** (e.g., `0`, `1`, `2`) → regular tracks via `self.song.tracks[index]`
- **"master"** or **"main"** (case-insensitive) → `self.song.master_track`
- **Return track prefix** (e.g., `"A"`, `"B"`) → matches against `self.song.return_tracks` names (format: "A-Reverb", "B-Delay")

### 2. Track API: Master and Return Track Support

**File**: `abletonosc/track.py`

#### Changes:
- Refactored `track_callback` to use the shared `_resolve_track()` helper
- Extended wildcard `"*"` to include master and return tracks

#### New Usage:
```bash
# Access master track
/live/track/get/output_meter_level master
/live/track/get/volume master
/live/track/set/volume master 0.75

# Access return tracks by prefix
/live/track/get/output_meter_level A
/live/track/get/volume B
/live/track/set/mute A 1

# Wildcard now includes master + returns
/live/track/get/name *
# Returns: track_0_name, track_1_name, ..., master_name, A-Reverb, B-Delay, ...
```

### 3. Device API: Master and Return Track Support

**File**: `abletonosc/device.py`

#### Changes:
- Refactored `device_callback` to use the shared `_resolve_track()` helper

#### New Usage:
```bash
# Access devices on master track
/live/device/get/name master 0
/live/device/get/parameter/value master 0 2

# Access devices on return tracks
/live/device/get/name A 0
/live/device/set/parameter/value B 1 2 0.5
```

### 4. Song API: Extended Enumeration Functions

**File**: `abletonosc/song.py`

#### 4a. `song_get_track_names`

Extended to include master and return tracks when enumerating "all":

```bash
# No params: returns all track names including master + returns
/live/song/get/track_names

# With -1: returns range + master + returns
/live/song/get/track_names 0 -1

# Explicit range: regular tracks only (existing behavior)
/live/song/get/track_names 0 5
```

#### 4b. `song_get_track_data`

Extended to process master and return tracks when `track_index_max == -1`:

```bash
# Includes master + returns
/live/song/get/track_data 0 -1 track.name track.volume

# Explicit range: regular tracks only
/live/song/get/track_data 0 5 track.name track.volume
```

**Note**: Handles tracks without `clip_slots` (master/returns don't have clips) gracefully.

#### 4c. `song_export_structure`

Always includes master and return tracks in the exported JSON:

**New JSON structure**:
```json
{
  "tracks": [
    // Regular tracks (existing)
  ],
  "master_track": {
    "name": "Master",
    "devices": [...]
  },
  "return_tracks": [
    {
      "index": 0,
      "name": "A-Reverb",
      "devices": [...]
    },
    {
      "index": 1,
      "name": "B-Delay",
      "devices": [...]
    }
  ]
}
```

## Technical Details

### Response Format

When using string identifiers, OSC responses include the string identifier:
- `/live/track/get/volume master` → `("master", 0.75)`
- `/live/track/get/volume A` → `("A", 0.8)`
- `/live/device/get/name master 0` → `("master", 0, "Compressor")`

This maintains consistency with the existing API where numeric indices are returned.

### Backward Compatibility

All changes are fully backward compatible:
- Existing numeric index usage works exactly as before
- Wildcard behavior is extended but maintains the same response format
- Explicit numeric ranges in song functions work unchanged

## Tests

### `tests/test_track.py`

New tests verify that track properties (name, volume, panning, mute, num\_devices) can be read and written using the string identifiers `"master"` / `"main"` for the master track and a return track prefix (e.g. `"A"`) for return tracks. A listener test confirms `start_listen` / `stop_listen` work correctly with the `"master"` identifier. Additional tests assert that an unrecognised string identifier returns `None` without crashing, and that pre-existing numeric integer indexing continues to work as before.

### `tests/test_song.py`

New tests cover the two modified endpoints:

- **`/live/song/get/track_names`** — verifies that a no-argument call (or a range ending in `-1`) includes the master and return tracks in the response, while an explicit numeric range excludes them.
- **`/live/song/get/track_data`** — verifies that a range ending in `-1` includes master/return track data, that an explicit range does not, and that querying `clip`, `clip_slot`, or `device` properties over a range that includes master/return tracks (which have no `clip_slots`) does not raise an error.


## Checklist

- [x] The title is descriptive and summarises the new changes
- [x] The code and any comments are consistent with the current code style
- [x] For any new or modified API endpoints, I have added appropriate documentation to [README.md](/README.md)
- [x] For any new or modified API endpoints, I have added [unit tests](/tests/) covering the new functionality
- [x] I have verified that all unit tests pass (see [CONTRIBUTING.md](/CONTRIBUTING.md) for guidance)