### PR TITLE
Add consolidated Browser API — supersedes #183/#191/#192/#194/#200

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,83 @@ Note that, for consistency with other object types (and Live's internal API), **
 
 ---
 
+## Browser API
+
+Exposes Live's content browser over OSC so that instruments, effects, samples, presets, and Max for Live devices can be loaded programmatically — useful for live performance setups, AI/MCP tool integrations, and headless scripting.
+
+<details>
+<summary><b>Documentation</b>: Browser API</summary>
+
+### Load items by name
+
+These endpoints search the named category tree and load the first match onto `track_index`. Matching is case-insensitive, prefers exact matches, falls back to substring matches.
+
+| Address                                  | Query params              | Response params | Description                                                                                          |
+|:-----------------------------------------|:--------------------------|:----------------|:-----------------------------------------------------------------------------------------------------|
+| /live/browser/load_instrument            | name, track_index         | name            | Load an instrument (searches `instruments`, `drums`, `sounds`)                                       |
+| /live/browser/load_drum_kit              | name, track_index         | name            | Load a drum kit (searches `drums`)                                                                   |
+| /live/browser/load_audio_effect          | name, track_index         | name            | Load an audio effect                                                                                 |
+| /live/browser/load_midi_effect           | name, track_index         | name            | Load a MIDI effect                                                                                   |
+| /live/browser/load_effect                | name, track_index         | name            | Load an effect (searches both audio and MIDI effect roots)                                           |
+| /live/browser/load_sound                 | name, track_index         | name            | Load a sound                                                                                         |
+| /live/browser/load_sample                | name, track_index         | name            | Load a sample                                                                                        |
+| /live/browser/load_plugin                | name, track_index         | name            | Load a VST/AU plugin (searches `plugins`, `instruments`, `audio_effects`)                            |
+| /live/browser/load_max_device            | name, track_index         | name            | Load a Max for Live device                                                                           |
+| /live/browser/load_user_preset           | name, track_index         | name            | Load a preset from the user library                                                                  |
+
+### Load by target
+
+| Address                                  | Query params                                  | Response params              | Description                                                                                                            |
+|:-----------------------------------------|:----------------------------------------------|:-----------------------------|:-----------------------------------------------------------------------------------------------------------------------|
+| /live/browser/load_to_slot               | category, name, track_index, slot_index       | name, track_index, slot_index | Load an item directly into a session-view clip slot                                                                    |
+| /live/browser/load_to_arrangement        | category, name, track_index, beat_time        | name, track_index, beat_time | Load an item at a position in the arrangement view (best-effort: the Live API does not support direct positional insertion) |
+
+### Load by query / category
+
+These endpoints don't require knowing the item's exact name. Returns an empty string if no match is found.
+
+| Address                                  | Query params                       | Response params | Description                                                                              |
+|:-----------------------------------------|:-----------------------------------|:----------------|:-----------------------------------------------------------------------------------------|
+| /live/browser/load_by_query              | track_index, query                 | name            | Search user-facing roots (sounds, instruments, drums, samples, packs, user_library) and load the first match |
+| /live/browser/load_from_category         | track_index, category, query       | name            | Restricted-scope search within a single category                                         |
+
+### Defaults
+
+Convenience one-shots for the common case of "just give me a working instrument / effect on this track".
+
+| Address                                          | Query params  | Response params | Description                                                                          |
+|:-------------------------------------------------|:--------------|:----------------|:-------------------------------------------------------------------------------------|
+| /live/browser/load_default_instrument            | track_index   | name            | Load a default synth (prefers Drift / Analog / Wavetable / Operator over samplers)   |
+| /live/browser/load_default_audio_effect          | track_index   | name            | Load a default audio effect (prefers Reverb / Delay / EQ Eight / Compressor / Utility) |
+| /live/browser/load_default_midi_effect           | track_index   | name            | Load a default MIDI effect (prefers Arpeggiator / Chord / Scale)                     |
+
+### Discovery
+
+| Address                                  | Query params                       | Response params      | Description                                                                              |
+|:-----------------------------------------|:-----------------------------------|:---------------------|:-----------------------------------------------------------------------------------------|
+| /live/browser/get/categories             |                                    | category_name, ...   | List available browser categories                                                        |
+| /live/browser/get/children               | category, [path...]                | child_name, ...      | List immediate children at a path within a category                                      |
+| /live/browser/search                     | query, [max_results=20]            | name, ...            | Search for loadable items across all main categories                                     |
+| /live/browser/list_audio_effects         |                                    | name, ...            | List all loadable audio effects                                                          |
+| /live/browser/list_midi_effects          |                                    | name, ...            | List all loadable MIDI effects                                                           |
+| /live/browser/list_sounds                |                                    | name, ...            | List all loadable sounds                                                                 |
+| /live/browser/list_plugins               |                                    | name, ...            | List all loadable plugins                                                                |
+| /live/browser/list_user_presets          |                                    | name, ...            | List all loadable user-library presets                                                   |
+
+### Preview, hotswap, utility
+
+| Address                                  | Query params                       | Response params | Description                                                                              |
+|:-----------------------------------------|:-----------------------------------|:----------------|:-----------------------------------------------------------------------------------------|
+| /live/browser/preview                    | category, name                     | name            | Preview an item through Live's preview channel                                           |
+| /live/browser/stop_preview               |                                    | "stopped"       | Stop the currently previewing item                                                       |
+| /live/browser/refresh                    |                                    | "refreshed"     | Force a browser cache invalidation                                                       |
+| /live/browser/hotswap_start              | track_index, device_index          | track_index, device_index | Enter hotswap mode for the given device                                       |
+| /live/browser/hotswap_load               | name                               | name            | Load an item into the current hotswap context                                            |
+
+</details>
+
+---
+
 # Utilities
 
 Included with the framework is a command-line console utility `run-console.py`, which can be used as a quick and easy way to send OSC queries to AbletonOSC. Example:

--- a/abletonosc/__init__.py
+++ b/abletonosc/__init__.py
@@ -13,4 +13,5 @@ from .device import DeviceHandler
 from .scene import SceneHandler
 from .view import ViewHandler
 from .midimap import MidiMapHandler
+from .browser import BrowserHandler
 from .constants import OSC_LISTEN_PORT, OSC_RESPONSE_PORT

--- a/abletonosc/browser.py
+++ b/abletonosc/browser.py
@@ -1,0 +1,693 @@
+from typing import Tuple, Any, List
+from .handler import AbletonOSCHandler
+import Live
+import logging
+
+logger = logging.getLogger("abletonosc")
+
+
+class BrowserHandler(AbletonOSCHandler):
+    def __init__(self, manager):
+        super().__init__(manager)
+        self.class_identifier = "browser"
+
+    @property
+    def browser(self):
+        return Live.Application.get_application().browser
+
+    # ---- Core helpers ----
+
+    def _get_category(self, category_name):
+        """Map a category string to a browser root item."""
+        attr_map = {
+            "instruments": "instruments",
+            "drums": "drums",
+            "audio_effects": "audio_effects",
+            "midi_effects": "midi_effects",
+            "sounds": "sounds",
+            "packs": "packs",
+            "samples": "samples",
+            "clips": "clips",
+            "max_for_live": "max_for_live",
+            "plugins": "plugins",
+            "user_library": "user_library",
+        }
+
+        attr_name = attr_map.get(category_name.lower())
+        if attr_name:
+            try:
+                return getattr(self.browser, attr_name)
+            except (AttributeError, RuntimeError):
+                pass
+
+        try:
+            for folder in self.browser.user_folders:
+                if folder.name.lower() == category_name.lower():
+                    return folder
+        except Exception:
+            pass
+
+        return None
+
+    def _match_name(self, child_name, search_name):
+        """
+        Compare names with tiered matching.
+        Returns: 3=exact/case-insensitive, 2=extension-stripped, 1=substring, 0=no match.
+        """
+        child_lower = child_name.lower()
+        search_lower = search_name.lower()
+        if child_lower == search_lower:
+            return 3
+        child_bare = child_name.rsplit(".", 1)[0].lower() if "." in child_name else child_lower
+        if child_bare == search_lower:
+            return 2
+        if search_lower in child_bare:
+            return 1
+        return 0
+
+    def _find_item(self, parent, name, max_depth=4, current_depth=0):
+        """
+        Search browser tree for an item by name.
+        Priority: exact/case-insensitive > extension-stripped > substring.
+        Returns first loadable match at highest priority, or None.
+        """
+        if current_depth > max_depth:
+            return None
+        try:
+            children = list(parent.children)
+        except Exception:
+            return None
+
+        substring_match = None
+        folders_to_search = []
+
+        for child in children:
+            try:
+                child_name = child.name
+            except Exception:
+                continue
+
+            quality = self._match_name(child_name, name)
+
+            if quality >= 2:
+                if child.is_loadable:
+                    return child
+                if child.is_folder:
+                    result = self._find_item(child, name, max_depth, current_depth + 1)
+                    if result:
+                        return result
+            elif quality == 1 and child.is_loadable and not substring_match:
+                substring_match = child
+
+            if child.is_folder and quality < 2:
+                folders_to_search.append(child)
+
+        for folder in folders_to_search:
+            result = self._find_item(folder, name, max_depth, current_depth + 1)
+            if result:
+                return result
+
+        return substring_match
+
+    def _search_items(self, parent, query, results, max_results=20, max_depth=3, current_depth=0):
+        """Collect loadable items whose name contains the query string."""
+        if current_depth > max_depth or len(results) >= max_results:
+            return
+        try:
+            children = list(parent.children)
+        except Exception:
+            return
+        for child in children:
+            if len(results) >= max_results:
+                return
+            try:
+                child_name = child.name
+            except Exception:
+                continue
+            if query.lower() in child_name.lower() and child.is_loadable:
+                results.append(child_name)
+            if child.is_folder and current_depth < max_depth:
+                self._search_items(child, query, results, max_results, max_depth, current_depth + 1)
+
+    def _collect_loadable(self, parent, results, max_results=100, max_depth=2, current_depth=0):
+        """Collect all loadable item names from a browser tree."""
+        if current_depth > max_depth or len(results) >= max_results:
+            return
+        try:
+            children = list(parent.children)
+        except Exception:
+            return
+        for child in children:
+            if len(results) >= max_results:
+                return
+            try:
+                if child.is_loadable:
+                    results.append(child.name)
+                elif child.is_folder and current_depth < max_depth:
+                    self._collect_loadable(child, results, max_results, max_depth, current_depth + 1)
+            except Exception:
+                continue
+
+    def _get_children_info(self, parent):
+        """Get flattened (name, is_loadable, is_folder, ...) for immediate children."""
+        result = []
+        try:
+            for child in parent.children:
+                try:
+                    result.append(child.name)
+                    result.append(1 if child.is_loadable else 0)
+                    result.append(1 if child.is_folder else 0)
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        return tuple(result)
+
+    def _navigate_path(self, parent, path_parts):
+        """Navigate browser tree by path segments with fallback matching."""
+        current = parent
+        for part in path_parts:
+            found = None
+            try:
+                for child in current.children:
+                    if self._match_name(child.name, part) >= 2:
+                        found = child
+                        break
+            except Exception:
+                return None
+            if not found:
+                return None
+            current = found
+        return current
+
+    def _select_track(self, track_index):
+        """Select a track by index and return it."""
+        track = self.song.tracks[track_index]
+        self.song.view.selected_track = track
+        return track
+
+    def _load_from_categories(self, name, track_index, category_names):
+        """Search for and load an item by name across multiple categories."""
+        self._select_track(track_index)
+
+        for cat_name in category_names:
+            category = self._get_category(cat_name)
+            if category:
+                item = self._find_item(category, name)
+                if item:
+                    self.browser.load_item(item)
+                    logger.info("Loaded '%s' from %s onto track %d" % (item.name, cat_name, track_index))
+                    return (item.name,)
+
+        raise ValueError("Not found: %s (searched: %s)" % (name, ", ".join(category_names)))
+
+    def _refresh(self):
+        """Force browser cache invalidation by toggling filter_type."""
+        try:
+            original = self.browser.filter_type
+            try:
+                self.browser.filter_type = Live.Browser.FilterType.disabled_filter_type
+            except Exception:
+                self.browser.filter_type = 0 if original != 0 else 1
+            self.browser.filter_type = original
+            logger.info("Browser cache refreshed")
+        except Exception as e:
+            logger.warning("Browser refresh failed: %s" % e)
+
+    def _load_first_match(self, parent, preferred_names, track_index):
+        """Load the first item whose name appears in `preferred_names`, falling
+        back to the first loadable child. Used by the load_default_* endpoints.
+        Adapted from PR #183.
+        """
+        self._select_track(track_index)
+        try:
+            children = list(parent.children)
+        except Exception:
+            return None
+        for preferred in preferred_names:
+            for child in children:
+                try:
+                    if child.name == preferred and child.is_loadable:
+                        self.browser.load_item(child)
+                        return (child.name,)
+                except Exception:
+                    continue
+        for child in children:
+            try:
+                if child.is_loadable:
+                    self.browser.load_item(child)
+                    return (child.name,)
+            except Exception:
+                continue
+        return None
+
+    def _find_first_loadable(self, parent, query_lower, max_depth=4, current_depth=0):
+        """Walk a browser sub-tree and return the first loadable item whose name
+        contains `query_lower`. Used by load_by_query / load_from_category.
+        Adapted from PR #200.
+        """
+        if current_depth > max_depth:
+            return None
+        try:
+            children = list(parent.children)
+        except Exception:
+            return None
+        for child in children:
+            try:
+                if query_lower in child.name.lower() and child.is_loadable:
+                    return child
+            except Exception:
+                continue
+        for child in children:
+            try:
+                if child.is_folder:
+                    found = self._find_first_loadable(child, query_lower, max_depth, current_depth + 1)
+                    if found is not None:
+                        return found
+            except Exception:
+                continue
+        return None
+
+    # ---- API registration ----
+
+    def init_api(self):
+
+        # ---- Load by name (10 endpoints) ----
+
+        def load_instrument(params: Tuple[Any]):
+            """/live/browser/load_instrument (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["instruments", "drums", "sounds"])
+
+        def load_drum_kit(params: Tuple[Any]):
+            """/live/browser/load_drum_kit (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["drums"])
+
+        def load_audio_effect(params: Tuple[Any]):
+            """/live/browser/load_audio_effect (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["audio_effects"])
+
+        def load_midi_effect(params: Tuple[Any]):
+            """/live/browser/load_midi_effect (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["midi_effects"])
+
+        def load_effect(params: Tuple[Any]):
+            """/live/browser/load_effect (name, track_index) — searches both audio and MIDI effects"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["audio_effects", "midi_effects"])
+
+        def load_sound(params: Tuple[Any]):
+            """/live/browser/load_sound (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["sounds"])
+
+        def load_sample(params: Tuple[Any]):
+            """/live/browser/load_sample (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["samples"])
+
+        def load_plugin(params: Tuple[Any]):
+            """/live/browser/load_plugin (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["plugins", "instruments", "audio_effects"])
+
+        def load_max_device(params: Tuple[Any]):
+            """/live/browser/load_max_device (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["max_for_live"])
+
+        def load_user_preset(params: Tuple[Any]):
+            """/live/browser/load_user_preset (name, track_index)"""
+            name, track_index = str(params[0]), int(params[1])
+            return self._load_from_categories(name, track_index, ["user_library"])
+
+        # ---- Load by target (2 endpoints) ----
+
+        def load_to_slot(params: Tuple[Any]):
+            """Load item into a specific session clip slot.
+            /live/browser/load_to_slot (category, name, track_index, slot_index)
+            Uses highlighted_clip_slot to target the exact slot.
+            """
+            category_name = str(params[0])
+            name = str(params[1])
+            track_index = int(params[2])
+            slot_index = int(params[3])
+
+            category = self._get_category(category_name)
+            if not category:
+                raise ValueError("Category not found: %s" % category_name)
+
+            item = self._find_item(category, name)
+            if not item:
+                raise ValueError("Not found in %s: %s" % (category_name, name))
+
+            app = Live.Application.get_application()
+            track = self.song.tracks[track_index]
+            scene = self.song.scenes[slot_index]
+            clip_slot = track.clip_slots[slot_index]
+
+            try:
+                app.view.show_view("Session")
+                app.view.focus_view("Session")
+            except Exception:
+                pass
+
+            self.song.view.selected_track = track
+            self.song.view.selected_scene = scene
+            self.song.view.highlighted_clip_slot = clip_slot
+
+            self.browser.load_item(item)
+            logger.info("Loaded '%s' to slot (track %d, slot %d)" % (item.name, track_index, slot_index))
+            return (item.name, track_index, slot_index)
+
+        def load_to_arrangement(params: Tuple[Any]):
+            """Load item at a position in arrangement view.
+            /live/browser/load_to_arrangement (category, name, track_index, beat_time)
+            Note: arrangement targeting is best-effort as the Live API
+            does not support direct positional insertion.
+            """
+            category_name = str(params[0])
+            name = str(params[1])
+            track_index = int(params[2])
+            beat_time = float(params[3])
+
+            category = self._get_category(category_name)
+            if not category:
+                raise ValueError("Category not found: %s" % category_name)
+
+            item = self._find_item(category, name)
+            if not item:
+                raise ValueError("Not found in %s: %s" % (category_name, name))
+
+            app = Live.Application.get_application()
+            track = self.song.tracks[track_index]
+
+            try:
+                app.view.show_view("Arranger")
+                app.view.focus_view("Arranger")
+            except Exception:
+                pass
+
+            self.song.view.selected_track = track
+            self.song.current_song_time = beat_time
+
+            self.browser.load_item(item)
+            logger.info("Loaded '%s' to arrangement (track %d, beat %.1f)" % (item.name, track_index, beat_time))
+            return (item.name, track_index, beat_time)
+
+        # ---- Discovery (8 endpoints) ----
+
+        def get_categories(params: Tuple[Any]):
+            """/live/browser/get/categories — list available browser categories"""
+            categories = []
+            for attr_name in ["instruments", "drums", "audio_effects", "midi_effects",
+                              "sounds", "packs", "samples", "clips", "max_for_live",
+                              "plugins", "user_library"]:
+                try:
+                    cat = getattr(self.browser, attr_name)
+                    if cat:
+                        categories.append(attr_name)
+                except (AttributeError, RuntimeError):
+                    pass
+            return tuple(categories)
+
+        def get_children(params: Tuple[Any]):
+            """List children of a browser path.
+            /live/browser/get/children (category, [path_part1, ...])
+            Returns flat tuple of child names.
+            """
+            category_name = str(params[0])
+            path_parts = [str(p) for p in params[1:]] if len(params) > 1 else []
+
+            category = self._get_category(category_name)
+            if not category:
+                raise ValueError("Category not found: %s" % category_name)
+
+            if path_parts:
+                target = self._navigate_path(category, path_parts)
+                if not target:
+                    raise ValueError("Path not found: %s/%s" % (category_name, "/".join(path_parts)))
+            else:
+                target = category
+
+            names = []
+            try:
+                for child in target.children:
+                    try:
+                        names.append(child.name)
+                    except Exception:
+                        continue
+            except Exception:
+                pass
+            return tuple(names)
+
+        def search(params: Tuple[Any]):
+            """/live/browser/search (query, [max_results])"""
+            query = str(params[0])
+            max_results = int(params[1]) if len(params) > 1 else 20
+            results = []
+
+            for cat_name in ["instruments", "drums", "audio_effects", "midi_effects",
+                             "sounds", "samples", "plugins", "max_for_live"]:
+                category = self._get_category(cat_name)
+                if category:
+                    self._search_items(category, query, results, max_results=max_results, max_depth=4)
+
+            return tuple(results)
+
+        def list_audio_effects(params: Tuple[Any]):
+            """/live/browser/list_audio_effects"""
+            results = []
+            category = self._get_category("audio_effects")
+            if category:
+                self._collect_loadable(category, results)
+            return tuple(results)
+
+        def list_midi_effects(params: Tuple[Any]):
+            """/live/browser/list_midi_effects"""
+            results = []
+            category = self._get_category("midi_effects")
+            if category:
+                self._collect_loadable(category, results)
+            return tuple(results)
+
+        def list_sounds(params: Tuple[Any]):
+            """/live/browser/list_sounds"""
+            results = []
+            category = self._get_category("sounds")
+            if category:
+                self._collect_loadable(category, results)
+            return tuple(results)
+
+        def list_plugins(params: Tuple[Any]):
+            """/live/browser/list_plugins"""
+            results = []
+            category = self._get_category("plugins")
+            if category:
+                self._collect_loadable(category, results)
+            return tuple(results)
+
+        def list_user_presets(params: Tuple[Any]):
+            """/live/browser/list_user_presets"""
+            results = []
+            category = self._get_category("user_library")
+            if category:
+                self._collect_loadable(category, results)
+            return tuple(results)
+
+        # ---- Preview (2 endpoints) ----
+
+        def preview(params: Tuple[Any]):
+            """/live/browser/preview (category, name)"""
+            category_name = str(params[0])
+            name = str(params[1])
+
+            category = self._get_category(category_name)
+            if not category:
+                raise ValueError("Category not found: %s" % category_name)
+
+            item = self._find_item(category, name)
+            if not item:
+                raise ValueError("Not found in %s: %s" % (category_name, name))
+
+            self.browser.preview_item(item)
+            logger.info("Previewing: %s" % item.name)
+            return (item.name,)
+
+        def stop_preview(params: Tuple[Any]):
+            """/live/browser/stop_preview"""
+            self.browser.stop_preview()
+            return ("stopped",)
+
+        # ---- Utility (3 endpoints) ----
+
+        def refresh(params: Tuple[Any]):
+            """/live/browser/refresh — force browser cache invalidation"""
+            self._refresh()
+            return ("refreshed",)
+
+        def hotswap_start(params: Tuple[Any]):
+            """Enter hotswap mode for a device.
+            /live/browser/hotswap_start (track_index, device_index)
+            """
+            track_index = int(params[0])
+            device_index = int(params[1])
+            track = self.song.tracks[track_index]
+            device = track.devices[device_index]
+            self.browser.hotswap_target = device
+            logger.info("Hotswap started for device %d on track %d" % (device_index, track_index))
+            return (track_index, device_index)
+
+        # ---- Defaults (3 endpoints, from PR #183) ----
+
+        def load_default_instrument(params: Tuple[Any]):
+            """/live/browser/load_default_instrument (track_index)
+            Loads the first available synthesiser onto the track, preferring
+            Drift / Analog / Wavetable / Operator over samplers so audible
+            sound is produced without further user action.
+            """
+            track_index = int(params[0])
+            preferred = ["Drift", "Analog", "Wavetable", "Operator", "Tension", "Collision"]
+            result = self._load_first_match(self.browser.instruments, preferred, track_index)
+            if result is None:
+                raise ValueError("No loadable instrument found")
+            return result
+
+        def load_default_audio_effect(params: Tuple[Any]):
+            """/live/browser/load_default_audio_effect (track_index)
+            Loads the first available audio effect from the preferred list
+            (Reverb / Delay / EQ Eight / Compressor / Utility).
+            """
+            track_index = int(params[0])
+            preferred = ["Reverb", "Delay", "EQ Eight", "Compressor", "Utility"]
+            result = self._load_first_match(self.browser.audio_effects, preferred, track_index)
+            if result is None:
+                raise ValueError("No loadable audio effect found")
+            return result
+
+        def load_default_midi_effect(params: Tuple[Any]):
+            """/live/browser/load_default_midi_effect (track_index)
+            Loads the first available MIDI effect from the preferred list
+            (Arpeggiator / Chord / Scale / Note Length / Pitch).
+            """
+            track_index = int(params[0])
+            preferred = ["Arpeggiator", "Chord", "Scale", "Note Length", "Pitch"]
+            result = self._load_first_match(self.browser.midi_effects, preferred, track_index)
+            if result is None:
+                raise ValueError("No loadable MIDI effect found")
+            return result
+
+        # ---- Query-based loading (2 endpoints, from PR #200) ----
+
+        def load_by_query(params: Tuple[Any]):
+            """/live/browser/load_by_query (track_index, query)
+            Search across user-facing roots (sounds, instruments, drums, samples,
+            packs, user_library) in priority order and load the first loadable
+            item whose name contains `query` onto the specified track.
+            Returns the loaded item's name, or empty string if nothing matched.
+            """
+            track_index = int(params[0])
+            query = str(params[1])
+            query_lower = query.lower()
+            self._select_track(track_index)
+
+            for cat_name in ("sounds", "instruments", "drums", "samples", "packs", "user_library"):
+                root = self._get_category(cat_name)
+                if root is None:
+                    continue
+                item = self._find_first_loadable(root, query_lower)
+                if item is not None:
+                    self.browser.load_item(item)
+                    logger.info("load_by_query: loaded '%s' from %s onto track %d" % (item.name, cat_name, track_index))
+                    return (item.name,)
+            return ("",)
+
+        def load_from_category(params: Tuple[Any]):
+            """/live/browser/load_from_category (track_index, category, query)
+            Restricted-scope search: load the first loadable item in `category`
+            whose name contains `query`. Returns the loaded item's name, or
+            empty string if nothing matched.
+            """
+            track_index = int(params[0])
+            category = str(params[1])
+            query = str(params[2])
+            query_lower = query.lower()
+            self._select_track(track_index)
+
+            root = self._get_category(category)
+            if root is None:
+                raise ValueError("Category not found: %s" % category)
+
+            item = self._find_first_loadable(root, query_lower)
+            if item is None:
+                return ("",)
+            self.browser.load_item(item)
+            logger.info("load_from_category: loaded '%s' from %s onto track %d" % (item.name, category, track_index))
+            return (item.name,)
+
+        def hotswap_load(params: Tuple[Any]):
+            """Load an item in the current hotswap context.
+            /live/browser/hotswap_load (name)
+            """
+            name = str(params[0])
+
+            for cat_name in ["instruments", "drums", "audio_effects", "midi_effects",
+                             "sounds", "plugins", "max_for_live", "user_library"]:
+                category = self._get_category(cat_name)
+                if category:
+                    item = self._find_item(category, name)
+                    if item:
+                        self.browser.load_item(item)
+                        logger.info("Hotswap loaded: %s" % item.name)
+                        return (item.name,)
+
+            raise ValueError("Not found for hotswap: %s" % name)
+
+        # ---- Register all handlers ----
+
+        # Load by name
+        self.osc_server.add_handler("/live/browser/load_instrument", load_instrument)
+        self.osc_server.add_handler("/live/browser/load_drum_kit", load_drum_kit)
+        self.osc_server.add_handler("/live/browser/load_audio_effect", load_audio_effect)
+        self.osc_server.add_handler("/live/browser/load_midi_effect", load_midi_effect)
+        self.osc_server.add_handler("/live/browser/load_effect", load_effect)
+        self.osc_server.add_handler("/live/browser/load_sound", load_sound)
+        self.osc_server.add_handler("/live/browser/load_sample", load_sample)
+        self.osc_server.add_handler("/live/browser/load_plugin", load_plugin)
+        self.osc_server.add_handler("/live/browser/load_max_device", load_max_device)
+        self.osc_server.add_handler("/live/browser/load_user_preset", load_user_preset)
+
+        # Load by target
+        self.osc_server.add_handler("/live/browser/load_to_slot", load_to_slot)
+        self.osc_server.add_handler("/live/browser/load_to_arrangement", load_to_arrangement)
+
+        # Discovery
+        self.osc_server.add_handler("/live/browser/get/categories", get_categories)
+        self.osc_server.add_handler("/live/browser/get/children", get_children)
+        self.osc_server.add_handler("/live/browser/search", search)
+        self.osc_server.add_handler("/live/browser/list_audio_effects", list_audio_effects)
+        self.osc_server.add_handler("/live/browser/list_midi_effects", list_midi_effects)
+        self.osc_server.add_handler("/live/browser/list_sounds", list_sounds)
+        self.osc_server.add_handler("/live/browser/list_plugins", list_plugins)
+        self.osc_server.add_handler("/live/browser/list_user_presets", list_user_presets)
+
+        # Preview
+        self.osc_server.add_handler("/live/browser/preview", preview)
+        self.osc_server.add_handler("/live/browser/stop_preview", stop_preview)
+
+        # Defaults (from PR #183)
+        self.osc_server.add_handler("/live/browser/load_default_instrument", load_default_instrument)
+        self.osc_server.add_handler("/live/browser/load_default_audio_effect", load_default_audio_effect)
+        self.osc_server.add_handler("/live/browser/load_default_midi_effect", load_default_midi_effect)
+
+        # Query-based loading (from PR #200)
+        self.osc_server.add_handler("/live/browser/load_by_query", load_by_query)
+        self.osc_server.add_handler("/live/browser/load_from_category", load_from_category)
+
+        # Utility
+        self.osc_server.add_handler("/live/browser/refresh", refresh)
+        self.osc_server.add_handler("/live/browser/hotswap_start", hotswap_start)
+        self.osc_server.add_handler("/live/browser/hotswap_load", hotswap_load)

--- a/abletonosc/browser.py
+++ b/abletonosc/browser.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Any, List
+from typing import Tuple, Any
 from .handler import AbletonOSCHandler
 import Live
 import logging

--- a/manager.py
+++ b/manager.py
@@ -100,6 +100,7 @@ class Manager(ControlSurface):
                 abletonosc.ViewHandler(self),
                 abletonosc.SceneHandler(self),
                 abletonosc.MidiMapHandler(self),
+                abletonosc.BrowserHandler(self),
             ]
 
     def clear_api(self):
@@ -130,6 +131,7 @@ class Manager(ControlSurface):
             importlib.reload(abletonosc.song)
             importlib.reload(abletonosc.track)
             importlib.reload(abletonosc.view)
+            importlib.reload(abletonosc.browser)
             importlib.reload(abletonosc)
         except Exception as e:
             exc = traceback.format_exc()

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,0 +1,114 @@
+from . import client, wait_one_tick
+
+#--------------------------------------------------------------------------------
+# Tests for the Browser API.
+#
+# These tests rely on devices that ship with every standard Live install:
+#   - "Simpler"  (instrument, included since Live Intro)
+#   - "Reverb"   (audio effect, included since Live 1)
+#
+# The lifecycle tests load a device onto a track, verify it shows up in the
+# track's device list, mutate parameter 0 (which is always "Device On"
+# across every Live device), restore it, and then delete the device, asserting
+# that the track returns to its original device count.
+#
+# Tracks 0 (MIDI) and 2 (Audio) are used to match the convention in the other
+# test modules. If a previous test run left devices behind, the autouse
+# fixture below clears the test tracks before each test.
+#--------------------------------------------------------------------------------
+
+import pytest
+
+
+def _track_num_devices(client, track_id):
+    return client.query("/live/track/get/num_devices", (track_id,))[1]
+
+
+def _device_param_value(client, track_id, device_id, param_index):
+    return client.query("/live/device/get/parameter/value",
+                        (track_id, device_id, param_index))[3]
+
+
+def _purge_track_devices(client, track_id):
+    num = _track_num_devices(client, track_id)
+    for device_id in reversed(range(num)):
+        client.send_message("/live/track/delete_device", (track_id, device_id))
+        wait_one_tick()
+
+
+@pytest.fixture(autouse=True)
+def _clean_test_tracks(client):
+    """Ensure tracks 0 and 2 have no devices before and after each test."""
+    _purge_track_devices(client, 0)
+    _purge_track_devices(client, 2)
+    yield
+    _purge_track_devices(client, 0)
+    _purge_track_devices(client, 2)
+
+
+def _assert_load_modify_delete(client, load_address, device_name, track_id):
+    """Run the load -> verify -> mutate -> restore -> delete -> verify cycle."""
+    initial_count = _track_num_devices(client, track_id)
+
+    client.send_message(load_address, (device_name, track_id))
+    wait_one_tick()
+
+    new_count = _track_num_devices(client, track_id)
+    assert new_count == initial_count + 1, \
+        "Expected device count to grow by 1 (loading %s onto track %d); got %d -> %d" % \
+        (device_name, track_id, initial_count, new_count)
+
+    device_id = new_count - 1
+    device_names = client.query("/live/track/get/devices/name", (track_id,))
+    loaded_name = device_names[1 + device_id]
+    assert device_name.lower() in loaded_name.lower(), \
+        "Expected '%s' in loaded device name; got: %s" % (device_name, loaded_name)
+
+    # Parameter 0 is always "Device On" — a 0.0/1.0 toggle that is safe to mutate.
+    original_value = _device_param_value(client, track_id, device_id, 0)
+    target_value = 0.0 if original_value >= 0.5 else 1.0
+
+    client.send_message("/live/device/set/parameter/value",
+                        (track_id, device_id, 0, target_value))
+    wait_one_tick()
+    assert _device_param_value(client, track_id, device_id, 0) == target_value
+
+    # Restore so we don't leave the test fixture in a surprising state.
+    client.send_message("/live/device/set/parameter/value",
+                        (track_id, device_id, 0, original_value))
+    wait_one_tick()
+
+    client.send_message("/live/track/delete_device", (track_id, device_id))
+    wait_one_tick()
+
+    final_count = _track_num_devices(client, track_id)
+    assert final_count == initial_count, \
+        "Expected device to be removed (count back to %d); got %d" % \
+        (initial_count, final_count)
+
+
+def test_browser_load_instrument_lifecycle(client):
+    """Load Simpler onto a MIDI track, mutate a parameter, then delete it."""
+    _assert_load_modify_delete(client,
+                               load_address="/live/browser/load_instrument",
+                               device_name="Simpler",
+                               track_id=0)
+
+
+def test_browser_load_audio_effect_lifecycle(client):
+    """Load Reverb onto an audio track, mutate a parameter, then delete it."""
+    _assert_load_modify_delete(client,
+                               load_address="/live/browser/load_audio_effect",
+                               device_name="Reverb",
+                               track_id=2)
+
+
+def test_browser_get_categories(client):
+    """Smoke test: /live/browser/get/categories returns a non-empty tuple
+    containing at least the always-present core categories."""
+    response = client.query("/live/browser/get/categories", ())
+    categories = set(response)
+    # Every Live install exposes at least these top-level browser roots.
+    expected_minimum = {"instruments", "audio_effects", "midi_effects"}
+    assert expected_minimum.issubset(categories), \
+        "Expected categories to include %s; got %s" % (expected_minimum, categories)


### PR DESCRIPTION
## Description

Consolidates five competing open Browser API PRs into a single handler. The five PRs (#183, #191, #192, #194, #200) all add overlapping `/live/browser/*` endpoints but none of them has been merged — they've sat open for weeks/months while the maintainer reviews other work. This PR is an attempt to unblock that by reducing five reviews to one.

The intent is: **if this is mergeable, the other five can be closed as consolidated-here.** If anything in here is the wrong call, please push back on this PR and I'll either fix it or close this and defer to the originals.

## Source PRs being consolidated

| PR  | Author | LOC | Status this PR | Notes |
|-----|--------|-----|----------------|-------|
| #194 | @bimsonz (Zach Bimson) | +546 | **Spine** — used verbatim | Already explicitly consolidates #183/#191/#192. Best-structured, follows AbletonOSC handler conventions, 25 endpoints. |
| #183 | @christopherwxyz | +924 | Partial absorb | `load_default_instrument`, `load_default_audio_effect`, `load_default_midi_effect` adapted into #194's style. Other endpoints either already in #194 or skipped to keep diff lean. |
| #191 | @keepyourpolicy-lab | +799 | Absorbed via #194 | Browser portion absorbed into #194 already. Chain/sidechain bits in #191 are out of scope here. |
| #192 | @Dandiggas | +352 | Absorbed via #194 | Already absorbed by #194 (`load_to_slot`, `load_to_arrangement`, `preview`). |
| #200 | @keshav55 (Keshav Rao) | +249 | Partial absorb | `load_by_query` and `load_from_category` adapted into #194's style. Genuinely new functionality — search-based loading that doesn't require an exact name. Valuable for AI/MCP integrations. |

All five contributors credited as `Co-authored-by` on the commit.

## Endpoint inventory (30 endpoints)

**Load by name (10):** `load_instrument`, `load_drum_kit`, `load_audio_effect`, `load_midi_effect`, `load_effect`, `load_sound`, `load_sample`, `load_plugin`, `load_max_device`, `load_user_preset`

**Load by target (2):** `load_to_slot`, `load_to_arrangement`

**Load by query / category (2, from #200):** `load_by_query`, `load_from_category`

**Defaults (3, from #183):** `load_default_instrument`, `load_default_audio_effect`, `load_default_midi_effect`

**Discovery (8):** `get/categories`, `get/children`, `search`, `list_audio_effects`, `list_midi_effects`, `list_sounds`, `list_plugins`, `list_user_presets`

**Preview, hotswap, utility (5):** `preview`, `stop_preview`, `refresh`, `hotswap_start`, `hotswap_load`

## Files changed

- `abletonosc/browser.py` — new, 693 lines (PR #194's body + two helper methods + five new endpoint functions + five `add_handler` registrations)
- `abletonosc/__init__.py` — `from .browser import BrowserHandler`
- `manager.py` — `BrowserHandler(self)` registration + `importlib.reload(abletonosc.browser)`
- `README.md` — new Browser API section, six sub-tables grouping the endpoints

## What I did NOT include and why

- `load_file` from #192 — loads from an arbitrary filesystem path; mild security concern (lets any OSC client read files outside the User Library). Skipped, can be revisited.
- `load_preset` from #191 — overlaps with `load_user_preset` already in the spine.
- `get_item_info`, `browse_path`, `list_samples`, `list_max_devices`, `list_clips` from #183 — small individual value, would add ~150 lines for marginal gain. Easy to add in a follow-up.
- `list_categories` / `list_children` from #200 — naming conflicts with #194's `get/categories` / `get/children` (same semantics). Kept #194's naming for consistency with the rest of AbletonOSC's `get/*` convention.

## On the meta — five competing PRs

This is the kind of pile-up that ages a repo. Daniel: if this consolidation works as a pattern, I'd be happy to do the same triage for other stalled clusters (e.g. the chain/master-return PRs around #170, #189, #170, #186, #197). Just say the word.

## Checklist

- [x] Title descriptive
- [x] Code style consistent with #194 (which followed AbletonOSC conventions)
- [x] README updated with a full Browser API section
- [ ] Unit tests — **deferred**. Browser tests are non-deterministic because they depend on what's installed in the user's Ableton library. A smoke test for `get/categories` is feasible; full coverage isn't. Happy to add a smoke test if you want one.
- [ ] All unit tests pass — **I do not have Live running on this machine**. The file syntax-checks and the diffs match PR #194's tested code. Please run locally before merging.
