### PR TITLE
Add /live/track/create_audio_clip + create_midi_clip — consolidates #168, #196

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,11 @@ To query the properties of multiple tracks, see [Song: Properties of cue points,
 
 ### Track methods
 
-| Address                    | Query params | Response params | Description             |
-|:---------------------------|:-------------|:----------------|:------------------------|
-| /live/track/stop_all_clips | track_id     |                 | Stop all clips on track |
+| Address                       | Query params                  | Response params | Description                                                                                                       |
+|:------------------------------|:------------------------------|:----------------|:------------------------------------------------------------------------------------------------------------------|
+| /live/track/stop_all_clips    | track_id                      |                 | Stop all clips on track                                                                                           |
+| /live/track/create_audio_clip | track_id, file_path, position |                 | Create an audio clip on the track in **arrangement view** by importing the sample at `file_path` at `position` beats. Not for session view — use `/live/clip_slot/create_clip` to create a session clip. |
+| /live/track/create_midi_clip  | track_id, position, length    |                 | Create a MIDI clip on the track in **arrangement view** at `position` beats, with the given `length` in beats. Not for session view — use `/live/clip_slot/create_clip` to create a session clip. |
 
 ### Track properties
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ To query the properties of multiple tracks, see [Song: Properties of cue points,
 |:------------------------------|:------------------------------|:----------------|:------------------------------------------------------------------------------------------------------------------|
 | /live/track/stop_all_clips    | track_id                      |                 | Stop all clips on track                                                                                           |
 | /live/track/create_audio_clip | track_id, file_path, position |                 | Create an audio clip on the track in **arrangement view** by importing the sample at `file_path` at `position` beats. Not for session view — use `/live/clip_slot/create_clip` to create a session clip. |
-| /live/track/create_midi_clip  | track_id, position, length    |                 | Create a MIDI clip on the track in **arrangement view** at `position` beats, with the given `length` in beats. Not for session view — use `/live/clip_slot/create_clip` to create a session clip. |
+| /live/track/create_midi_clip  | track_id, start_time, end_time |                | Create a MIDI clip on the track in **arrangement view** spanning `start_time` to `end_time` (both in beats), matching the LOM signature `Track.create_midi_clip(start_time, end_time)`. Not for session view — use `/live/clip_slot/create_clip` to create a session clip. |
 
 ### Track properties
 

--- a/abletonosc/track.py
+++ b/abletonosc/track.py
@@ -30,6 +30,8 @@ class TrackHandler(AbletonOSCHandler):
             return track_callback
 
         methods = [
+            "create_audio_clip",
+            "create_midi_clip",
             "delete_device",
             "stop_all_clips"
         ]

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -76,6 +76,61 @@ def test_track_devices(client):
     assert client.query("/live/track/get/num_devices", (track_id,)) == (track_id, 0,)
 
 #--------------------------------------------------------------------------------
+# /live/track/create_midi_clip and /live/track/create_audio_clip exercise the
+# arrangement-view clip creation surface of the Live API. They do not affect
+# the session view — that surface is served by /live/clip_slot/create_clip.
+#
+# These tests use /live/song/undo to roll back state after each create, so the
+# test set is left as it was found.
+#--------------------------------------------------------------------------------
+
+def test_track_create_midi_clip_in_arrangement(client):
+    track_id = 0
+    start_time, end_time = 0.0, 4.0
+
+    initial = client.query("/live/track/get/arrangement_clips/name", (track_id,))
+
+    client.send_message("/live/track/create_midi_clip", (track_id, start_time, end_time))
+    wait_one_tick()
+
+    after = client.query("/live/track/get/arrangement_clips/name", (track_id,))
+    # (track_id,) is the response prefix; after the new clip there must be one
+    # more entry than before.
+    assert len(after) == len(initial) + 1, \
+        "Expected arrangement clip count to grow by 1; before=%s after=%s" % (initial, after)
+
+    # Undo to clean up — create_midi_clip is undoable per the LOM contract.
+    client.send_message("/live/song/undo", ())
+    wait_one_tick()
+
+def test_track_create_audio_clip_in_arrangement(client, tmp_path):
+    """Generate a one-second silent WAV on disk and import it as an arrangement
+    audio clip onto track 2 (the default test audio track). Undo afterwards."""
+    import wave
+    wav_path = tmp_path / "abletonosc_test_silence.wav"
+    with wave.open(str(wav_path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(44100)
+        wf.writeframes(b"\x00\x00" * 44100)
+
+    track_id = 2
+    position = 0.0
+
+    initial = client.query("/live/track/get/arrangement_clips/name", (track_id,))
+
+    client.send_message("/live/track/create_audio_clip",
+                        (track_id, str(wav_path), position))
+    wait_one_tick()
+
+    after = client.query("/live/track/get/arrangement_clips/name", (track_id,))
+    assert len(after) == len(initial) + 1, \
+        "Expected arrangement clip count to grow by 1; before=%s after=%s" % (initial, after)
+
+    client.send_message("/live/song/undo", ())
+    wait_one_tick()
+
+#--------------------------------------------------------------------------------
 # Test track properties - listeners
 #--------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Adds arrangement-view clip creation to the Track API:

- `/live/track/create_audio_clip (track_id, file_path, position)` — import a sample as an arrangement audio clip
- `/live/track/create_midi_clip (track_id, start_time, end_time)` — create an empty MIDI clip in arrangement

Both wire through the existing `_call_method` plumbing — minimal surface area, no new abstractions.

## Source PRs being consolidated

| PR  | Author | Status this PR | Notes |
|-----|--------|----------------|-------|
| #168 | @jmiceo (Julian Miceo Plak) | README + scope-tag absorbed | Daniel's review on #168 (2025-11): *"Can you extend the Description field in the README to explicitly state that the clip is added in arrangement view?"* — done here, with an explicit pointer to `/live/clip_slot/create_clip` for session-view users. |
| #196 | @bimsonz (Zach Bimson)       | Same change, no README       | Just adds the methods-list entries. Identical to #168's code change. |

Both contributors credited as `Co-authored-by`.

## Tests

Two new tests in `tests/test_track.py`:

- **`test_track_create_midi_clip_in_arrangement`** — creates a 4-beat MIDI clip on track 0, asserts the arrangement clip count grew by 1 via `/live/track/get/arrangement_clips/name`, then calls `/live/song/undo` to restore the test set.
- **`test_track_create_audio_clip_in_arrangement`** — generates a one-second silent WAV via the stdlib `wave` module into pytest's `tmp_path` (so the test doesn't depend on any sample shipping with the user's Live install), imports it onto track 2, asserts the count grew, then undoes.

## Files changed

- `abletonosc/track.py` — 2 lines added to the `methods` list
- `README.md` — 3 rows in Track methods table (replaces 1 existing row)
- `tests/test_track.py` — 2 new tests, +55 lines

**Total:** +62 / -3 across 3 files.

## Checklist

- [x] Title descriptive
- [x] Consistent with existing style (just appends to `methods` list — same pattern as `delete_device`, `stop_all_clips`)
- [x] README updated, with the explicit "arrangement view" scope tag you asked for on #168
- [x] Unit tests for both endpoints
- [ ] All unit tests pass — **I do not have Live running on this machine.** The tests were written by mirroring patterns in the existing `tests/test_track.py` and using `/live/song/undo` for cleanup so they don't pollute the fixture. Please run locally before merging.

If you'd prefer to merge #168 directly instead (with @jmiceo updating the README), that's also fine — happy to close this. The point of this PR is to give you a one-merge option.
