### PR TITLE
Add /live/view scroll_view, clip-envelope show/hide, and clip transposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Represents the view (user interface) of live
 | /live/view/stop_listen/selected_scene  |                          |                          | Stop listening to the selected scene (first scene = 0)  |
 | /live/view/stop_listen/selected_track  |                          |                          | Stop listening to selected track (first track = 0)      |
 | /live/view/scroll_view                 | direction                |                          | Scroll the currently focused view by one step in the given `direction` (`Live.Application.Application.View.NavDirection` — typically 0=up, 1=down, 2=left, 3=right). Wraps `Application.View.scroll_view(direction, "", False)`. |
+| /live/view/show_clip_envelope          |                          |                          | Focus Clip View and show the Envelopes box for the clip displayed there |
+| /live/view/hide_clip_envelope          |                          |                          | Hide the Envelopes box for the clip displayed in Clip View              |
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Represents the view (user interface) of live
 | /live/view/scroll_view                 | direction                |                          | Scroll the currently focused view by one step in the given `direction` (`Live.Application.Application.View.NavDirection` — typically 0=up, 1=down, 2=left, 3=right). Wraps `Application.View.scroll_view(direction, "", False)`. |
 | /live/view/show_clip_envelope          |                          |                          | Focus Clip View and show the Envelopes box for the clip displayed there |
 | /live/view/hide_clip_envelope          |                          |                          | Hide the Envelopes box for the clip displayed in Clip View              |
+| /live/view/nudge_clip_transposition    | semitones                | new_value                | Add `semitones` to the pitch_coarse of the clip displayed in Clip View, clamped to -48..48 |
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Represents the view (user interface) of live
 | /live/view/start_listen/selected_track |                          | selected_track           | Start listening to selected track (first track = 0)     |
 | /live/view/stop_listen/selected_scene  |                          |                          | Stop listening to the selected scene (first scene = 0)  |
 | /live/view/stop_listen/selected_track  |                          |                          | Stop listening to selected track (first track = 0)      |
+| /live/view/scroll_view                 | direction                |                          | Scroll the currently focused view by one step in the given `direction` (`Live.Application.Application.View.NavDirection` — typically 0=up, 1=down, 2=left, 3=right). Wraps `Application.View.scroll_view(direction, "", False)`. |
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Represents the view (user interface) of live
 | /live/view/show_clip_envelope          |                          |                          | Focus Clip View and show the Envelopes box for the clip displayed there |
 | /live/view/hide_clip_envelope          |                          |                          | Hide the Envelopes box for the clip displayed in Clip View              |
 | /live/view/nudge_clip_transposition    | semitones                | new_value                | Add `semitones` to the pitch_coarse of the clip displayed in Clip View, clamped to -48..48 |
+| /live/view/set_clip_transposition      | semitones                | new_value                | Set the pitch_coarse of the clip displayed in Clip View to `semitones`, clamped to -48..48 |
 </details>
 
 ---

--- a/abletonosc/view.py
+++ b/abletonosc/view.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import Optional, Tuple, Any
 import Live
 from .handler import AbletonOSCHandler
+import Live
 
 class ViewHandler(AbletonOSCHandler):
     def __init__(self, manager):
@@ -35,6 +36,32 @@ class ViewHandler(AbletonOSCHandler):
             device = self.song.tracks[params[0]].devices[params[1]]
             self.song.view.select_device(device)
             return params[0], params[1]
+
+        def show_clip_envelope(params: Optional[Tuple] = ()):
+            """
+            Focuses Clip View and shows the Envelopes box for the clip currently
+            displayed there.
+            """
+            clip = self.song.view.detail_clip
+            if clip is None:
+                raise RuntimeError("No clip is currently shown in Clip View")
+
+            Live.Application.get_application().view.focus_view("Detail/Clip")
+            clip.view.show_envelope()
+
+        def hide_clip_envelope(params: Optional[Tuple] = ()):
+            """
+            Hides the Envelopes box for the clip currently shown in Clip View,
+            returning it to the Sample (or Notes) editor.
+            """
+            clip = self.song.view.detail_clip
+            if clip is None:
+                raise RuntimeError("No clip is currently shown in Clip View")
+
+            clip.view.hide_envelope()
+
+        self.osc_server.add_handler("/live/view/show_clip_envelope", show_clip_envelope)
+        self.osc_server.add_handler("/live/view/hide_clip_envelope", hide_clip_envelope)
 
         self.osc_server.add_handler("/live/view/get/selected_scene", get_selected_scene)
         self.osc_server.add_handler("/live/view/get/selected_track", get_selected_track)

--- a/abletonosc/view.py
+++ b/abletonosc/view.py
@@ -1,5 +1,6 @@
 from functools import partial
 from typing import Optional, Tuple, Any
+import Live
 from .handler import AbletonOSCHandler
 
 class ViewHandler(AbletonOSCHandler):
@@ -48,3 +49,16 @@ class ViewHandler(AbletonOSCHandler):
         self.osc_server.add_handler('/live/view/start_listen/selected_track', partial(self._start_listen, self.song.view, "selected_track", getter=get_selected_track))
         self.osc_server.add_handler('/live/view/stop_listen/selected_scene', partial(self._stop_listen, self.song.view, "selected_scene"))
         self.osc_server.add_handler('/live/view/stop_listen/selected_track', partial(self._stop_listen, self.song.view, "selected_track"))
+
+        def scroll_view(params: Tuple[Any]):
+            #--------------------------------------------------------------------------------
+            # Wraps Live.Application.Application.View.scroll_view(direction, view_name="",
+            # shift_pressed=False). The direction integer maps to
+            # Live.Application.Application.View.NavDirection — typically 0=up, 1=down,
+            # 2=left, 3=right. We pass an empty view_name and shift_pressed=False so the
+            # scroll affects the currently focused view, matching Live's keyboard arrows.
+            #--------------------------------------------------------------------------------
+            direction = int(params[0])
+            Live.Application.get_application().view.scroll_view(direction, "", False)
+
+        self.osc_server.add_handler("/live/view/scroll_view", scroll_view)

--- a/abletonosc/view.py
+++ b/abletonosc/view.py
@@ -75,9 +75,31 @@ class ViewHandler(AbletonOSCHandler):
             clip.pitch_coarse = new_value
             return (new_value,)
 
+        def set_clip_transposition(params: Optional[Tuple] = ()):
+            """
+            Sets the pitch_coarse of the clip currently shown in Clip View to params[0]
+            semitones, clamped to Live's -48..48 range. Returns the new value.
+
+            Note: this sets the clip's scalar transposition. If a Transposition
+            envelope has already been drawn on the clip, the drawn curve still
+            determines playback -- Live's API has no way to clear a single warp
+            parameter's envelope (only clip.clear_all_envelopes(), which removes
+            every envelope on the clip, including unrelated ones).
+            """
+            clip = self.song.view.detail_clip
+            if clip is None:
+                raise RuntimeError("No clip is currently shown in Clip View")
+            if not clip.is_audio_clip:
+                raise RuntimeError("Transposition only applies to audio clips")
+
+            new_value = max(-48, min(48, int(params[0])))
+            clip.pitch_coarse = new_value
+            return (new_value,)
+
         self.osc_server.add_handler("/live/view/show_clip_envelope", show_clip_envelope)
         self.osc_server.add_handler("/live/view/hide_clip_envelope", hide_clip_envelope)
         self.osc_server.add_handler("/live/view/nudge_clip_transposition", nudge_clip_transposition)
+        self.osc_server.add_handler("/live/view/set_clip_transposition", set_clip_transposition)
 
         self.osc_server.add_handler("/live/view/get/selected_scene", get_selected_scene)
         self.osc_server.add_handler("/live/view/get/selected_track", get_selected_track)

--- a/abletonosc/view.py
+++ b/abletonosc/view.py
@@ -42,11 +42,17 @@ class ViewHandler(AbletonOSCHandler):
             Focuses Clip View and shows the Envelopes box for the clip currently
             displayed there.
             """
+            #--------------------------------------------------------------------------------
+            # Focus Clip View FIRST. detail_clip is empty while the detail pane is showing
+            # Device View, so checking it beforehand would refuse to do the very thing that
+            # would have made a clip available.
+            #--------------------------------------------------------------------------------
+            Live.Application.get_application().view.focus_view("Detail/Clip")
+
             clip = self.song.view.detail_clip
             if clip is None:
                 raise RuntimeError("No clip is currently shown in Clip View")
 
-            Live.Application.get_application().view.focus_view("Detail/Clip")
             clip.view.show_envelope()
 
         def hide_clip_envelope(params: Optional[Tuple] = ()):

--- a/abletonosc/view.py
+++ b/abletonosc/view.py
@@ -60,8 +60,24 @@ class ViewHandler(AbletonOSCHandler):
 
             clip.view.hide_envelope()
 
+        def nudge_clip_transposition(params: Optional[Tuple] = ()):
+            """
+            Adds params[0] semitones to the pitch_coarse of the clip currently shown in
+            Clip View, clamped to Live's -48..48 range. Returns the new value.
+            """
+            clip = self.song.view.detail_clip
+            if clip is None:
+                raise RuntimeError("No clip is currently shown in Clip View")
+            if not clip.is_audio_clip:
+                raise RuntimeError("Transposition only applies to audio clips")
+
+            new_value = max(-48, min(48, clip.pitch_coarse + int(params[0])))
+            clip.pitch_coarse = new_value
+            return (new_value,)
+
         self.osc_server.add_handler("/live/view/show_clip_envelope", show_clip_envelope)
         self.osc_server.add_handler("/live/view/hide_clip_envelope", hide_clip_envelope)
+        self.osc_server.add_handler("/live/view/nudge_clip_transposition", nudge_clip_transposition)
 
         self.osc_server.add_handler("/live/view/get/selected_scene", get_selected_scene)
         self.osc_server.add_handler("/live/view/get/selected_track", get_selected_track)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,3 +1,5 @@
+import pytest
+
 from . import client, wait_one_tick
 
 #--------------------------------------------------------------------------------
@@ -37,3 +39,89 @@ def test_scroll_view_smoke(client):
     # Sanity check: the OSC server is still answering after the four scrolls.
     rv = client.query("/live/view/get/selected_track")
     assert isinstance(rv, tuple) and len(rv) == 1
+
+
+#--------------------------------------------------------------------------------
+# Test the Clip View envelope endpoints.
+#
+# These act on song.view.detail_clip -- whatever clip Clip View is showing -- so each
+# test selects a clip first. The transposition pair require an AUDIO clip, hence the
+# recorded clip on track 2 (a default audio input device must be set, as in test_clip).
+#--------------------------------------------------------------------------------
+
+MIDI_TRACK_ID, MIDI_CLIP_ID = 0, 0
+AUDIO_TRACK_ID, AUDIO_CLIP_ID = 2, 0
+
+@pytest.fixture(scope="module")
+def _clips(client):
+    client.send_message("/live/clip_slot/create_clip", [MIDI_TRACK_ID, MIDI_CLIP_ID, 8.0])
+
+    client.send_message("/live/track/set/arm", [AUDIO_TRACK_ID, True])
+    client.send_message("/live/clip_slot/fire", [AUDIO_TRACK_ID, AUDIO_CLIP_ID])
+    wait_one_tick()
+    client.send_message("/live/song/stop_playing")
+    client.send_message("/live/song/stop_all_clips")
+    client.send_message("/live/track/set/arm", [AUDIO_TRACK_ID, False])
+    yield
+    client.send_message("/live/track/delete_clip", [AUDIO_TRACK_ID, AUDIO_CLIP_ID])
+    client.send_message("/live/track/delete_clip", [MIDI_TRACK_ID, MIDI_CLIP_ID])
+
+def _show_clip(client, track_id, clip_id):
+    """Puts a clip in Clip View, which is what detail_clip then reports."""
+    client.send_message("/live/view/set/selected_clip", (track_id, clip_id))
+    wait_one_tick()
+
+def test_view_clip_envelope_show_hide(client, _clips):
+    #--------------------------------------------------------------------------------
+    # Neither endpoint replies, so — as with scroll_view — the assertion is that the
+    # handler chain is still alive afterwards, i.e. neither call raised.
+    #--------------------------------------------------------------------------------
+    _show_clip(client, MIDI_TRACK_ID, MIDI_CLIP_ID)
+
+    client.send_message("/live/view/show_clip_envelope")
+    wait_one_tick()
+    client.send_message("/live/view/hide_clip_envelope")
+    wait_one_tick()
+
+    assert client.query("/live/view/get/selected_clip") == (MIDI_TRACK_ID, MIDI_CLIP_ID)
+
+def test_view_set_clip_transposition(client, _clips):
+    _show_clip(client, AUDIO_TRACK_ID, AUDIO_CLIP_ID)
+
+    for semitones in (12, -7, 0):
+        assert client.query("/live/view/set_clip_transposition", (semitones,)) == (semitones,)
+        wait_one_tick()
+        #--------------------------------------------------------------------------------
+        # Cross-check against the clip's own property, so this tests the write and not
+        # just the reply.
+        #--------------------------------------------------------------------------------
+        assert client.query("/live/clip/get/pitch_coarse", (AUDIO_TRACK_ID, AUDIO_CLIP_ID)) == \
+            (AUDIO_TRACK_ID, AUDIO_CLIP_ID, semitones)
+
+def test_view_set_clip_transposition_clamps(client, _clips):
+    _show_clip(client, AUDIO_TRACK_ID, AUDIO_CLIP_ID)
+
+    assert client.query("/live/view/set_clip_transposition", (100,)) == (48,)
+    wait_one_tick()
+    assert client.query("/live/view/set_clip_transposition", (-100,)) == (-48,)
+    wait_one_tick()
+    client.send_message("/live/view/set_clip_transposition", (0,))
+
+def test_view_nudge_clip_transposition(client, _clips):
+    _show_clip(client, AUDIO_TRACK_ID, AUDIO_CLIP_ID)
+    client.send_message("/live/view/set_clip_transposition", (0,))
+    wait_one_tick()
+
+    assert client.query("/live/view/nudge_clip_transposition", (12,)) == (12,)
+    wait_one_tick()
+    assert client.query("/live/view/nudge_clip_transposition", (12,)) == (24,)
+    wait_one_tick()
+    assert client.query("/live/view/nudge_clip_transposition", (-24,)) == (0,)
+    wait_one_tick()
+
+    # Nudging past the end clamps rather than wrapping.
+    client.send_message("/live/view/set_clip_transposition", (48,))
+    wait_one_tick()
+    assert client.query("/live/view/nudge_clip_transposition", (12,)) == (48,)
+    wait_one_tick()
+    client.send_message("/live/view/set_clip_transposition", (0,))

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -18,3 +18,22 @@ def test_selected_clip(client):
     client.send_message("/live/view/set/selected_clip", (3, 4))
     rv = client.query("/live/view/get/selected_clip")
     assert rv == (3, 4)
+
+def test_scroll_view_smoke(client):
+    #--------------------------------------------------------------------------------
+    # Smoke test: send each of the four NavDirection values and confirm the
+    # selected-scene/track endpoints still respond afterwards. scroll_view itself
+    # produces no OSC reply, so the assertion is "the OSC handler chain is alive
+    # after the call" rather than "the cursor moved to the expected place".
+    #--------------------------------------------------------------------------------
+    client.send_message("/live/view/set/selected_scene", (0,))
+    client.send_message("/live/view/set/selected_track", (0,))
+    wait_one_tick()
+
+    for direction in (0, 1, 2, 3):
+        client.send_message("/live/view/scroll_view", (direction,))
+        wait_one_tick()
+
+    # Sanity check: the OSC server is still answering after the four scrolls.
+    rv = client.query("/live/view/get/selected_track")
+    assert isinstance(rv, tuple) and len(rv) == 1

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,6 +1,6 @@
 import pytest
 
-from . import client, wait_one_tick
+from . import client, wait_one_tick, TICK_DURATION
 
 #--------------------------------------------------------------------------------
 # Test view features
@@ -40,6 +40,16 @@ def test_scroll_view_smoke(client):
     rv = client.query("/live/view/get/selected_track")
     assert isinstance(rv, tuple) and len(rv) == 1
 
+    #--------------------------------------------------------------------------------
+    # Put the selection back. Scrolling moves it, and on a set with return tracks it
+    # can land somewhere /live/view/get/selected_clip cannot express (it looks the
+    # selected track up in song.tracks), which then fails every later test that reads
+    # the selection — including test_selected_clip.
+    #--------------------------------------------------------------------------------
+    client.send_message("/live/view/set/selected_track", (0,))
+    client.send_message("/live/view/set/selected_scene", (0,))
+    wait_one_tick()
+
 
 #--------------------------------------------------------------------------------
 # Test the Clip View envelope endpoints.
@@ -49,47 +59,56 @@ def test_scroll_view_smoke(client):
 # recorded clip on track 2 (a default audio input device must be set, as in test_clip).
 #--------------------------------------------------------------------------------
 
-MIDI_TRACK_ID, MIDI_CLIP_ID = 0, 0
 AUDIO_TRACK_ID, AUDIO_CLIP_ID = 2, 0
 
 @pytest.fixture(scope="module")
-def _clips(client):
-    client.send_message("/live/clip_slot/create_clip", [MIDI_TRACK_ID, MIDI_CLIP_ID, 8.0])
-
+def _audio_clip(client):
+    #--------------------------------------------------------------------------------
+    # Records a brief audio clip, because pitch_coarse only exists on audio clips.
+    # Deliberately does not also create a MIDI clip: none of these tests need one, and
+    # requiring a MIDI track at a fixed index makes the fixture fail outright on a set
+    # whose first tracks are all audio.
+    #--------------------------------------------------------------------------------
     client.send_message("/live/track/set/arm", [AUDIO_TRACK_ID, True])
     client.send_message("/live/clip_slot/fire", [AUDIO_TRACK_ID, AUDIO_CLIP_ID])
     wait_one_tick()
     client.send_message("/live/song/stop_playing")
     client.send_message("/live/song/stop_all_clips")
     client.send_message("/live/track/set/arm", [AUDIO_TRACK_ID, False])
+    wait_one_tick()
     yield
     client.send_message("/live/track/delete_clip", [AUDIO_TRACK_ID, AUDIO_CLIP_ID])
-    client.send_message("/live/track/delete_clip", [MIDI_TRACK_ID, MIDI_CLIP_ID])
 
 def _show_clip(client, track_id, clip_id):
-    """Puts a clip in Clip View, which is what detail_clip then reports."""
+    """
+    Puts a clip in Clip View, which is what detail_clip then reports. show_clip_envelope
+    focuses Clip View, without which detail_clip stays empty when the detail pane happens
+    to be showing Device View.
+    """
     client.send_message("/live/view/set/selected_clip", (track_id, clip_id))
     wait_one_tick()
+    client.send_message("/live/view/show_clip_envelope")
+    wait_one_tick()
 
-def test_view_clip_envelope_show_hide(client, _clips):
+def test_view_clip_envelope_show_hide(client, _audio_clip):
     #--------------------------------------------------------------------------------
     # Neither endpoint replies, so — as with scroll_view — the assertion is that the
     # handler chain is still alive afterwards, i.e. neither call raised.
     #--------------------------------------------------------------------------------
-    _show_clip(client, MIDI_TRACK_ID, MIDI_CLIP_ID)
+    _show_clip(client, AUDIO_TRACK_ID, AUDIO_CLIP_ID)
 
     client.send_message("/live/view/show_clip_envelope")
     wait_one_tick()
     client.send_message("/live/view/hide_clip_envelope")
     wait_one_tick()
 
-    assert client.query("/live/view/get/selected_clip") == (MIDI_TRACK_ID, MIDI_CLIP_ID)
+    assert client.query("/live/view/get/selected_clip") == (AUDIO_TRACK_ID, AUDIO_CLIP_ID)
 
-def test_view_set_clip_transposition(client, _clips):
+def test_view_set_clip_transposition(client, _audio_clip):
     _show_clip(client, AUDIO_TRACK_ID, AUDIO_CLIP_ID)
 
     for semitones in (12, -7, 0):
-        assert client.query("/live/view/set_clip_transposition", (semitones,)) == (semitones,)
+        assert client.query("/live/view/set_clip_transposition", (semitones,), timeout=TICK_DURATION * 8) == (semitones,)
         wait_one_tick()
         #--------------------------------------------------------------------------------
         # Cross-check against the clip's own property, so this tests the write and not
@@ -98,30 +117,30 @@ def test_view_set_clip_transposition(client, _clips):
         assert client.query("/live/clip/get/pitch_coarse", (AUDIO_TRACK_ID, AUDIO_CLIP_ID)) == \
             (AUDIO_TRACK_ID, AUDIO_CLIP_ID, semitones)
 
-def test_view_set_clip_transposition_clamps(client, _clips):
+def test_view_set_clip_transposition_clamps(client, _audio_clip):
     _show_clip(client, AUDIO_TRACK_ID, AUDIO_CLIP_ID)
 
-    assert client.query("/live/view/set_clip_transposition", (100,)) == (48,)
+    assert client.query("/live/view/set_clip_transposition", (100,), timeout=TICK_DURATION * 8) == (48,)
     wait_one_tick()
-    assert client.query("/live/view/set_clip_transposition", (-100,)) == (-48,)
+    assert client.query("/live/view/set_clip_transposition", (-100,), timeout=TICK_DURATION * 8) == (-48,)
     wait_one_tick()
     client.send_message("/live/view/set_clip_transposition", (0,))
 
-def test_view_nudge_clip_transposition(client, _clips):
+def test_view_nudge_clip_transposition(client, _audio_clip):
     _show_clip(client, AUDIO_TRACK_ID, AUDIO_CLIP_ID)
     client.send_message("/live/view/set_clip_transposition", (0,))
     wait_one_tick()
 
-    assert client.query("/live/view/nudge_clip_transposition", (12,)) == (12,)
+    assert client.query("/live/view/nudge_clip_transposition", (12,), timeout=TICK_DURATION * 8) == (12,)
     wait_one_tick()
-    assert client.query("/live/view/nudge_clip_transposition", (12,)) == (24,)
+    assert client.query("/live/view/nudge_clip_transposition", (12,), timeout=TICK_DURATION * 8) == (24,)
     wait_one_tick()
-    assert client.query("/live/view/nudge_clip_transposition", (-24,)) == (0,)
+    assert client.query("/live/view/nudge_clip_transposition", (-24,), timeout=TICK_DURATION * 8) == (0,)
     wait_one_tick()
 
     # Nudging past the end clamps rather than wrapping.
     client.send_message("/live/view/set_clip_transposition", (48,))
     wait_one_tick()
-    assert client.query("/live/view/nudge_clip_transposition", (12,)) == (48,)
+    assert client.query("/live/view/nudge_clip_transposition", (12,), timeout=TICK_DURATION * 8) == (48,)
     wait_one_tick()
     client.send_message("/live/view/set_clip_transposition", (0,))


### PR DESCRIPTION
Five additions to the existing `/live/view/` namespace — `scroll_view` (the original of this PR,
closing #153) plus four for the Clip View envelope area.

| Endpoint | Params | Returns | Description |
|---|---|---|---|
| `/live/view/scroll_view` | direction | | Scroll the focused view one step (`NavDirection`: 0=up, 1=down, 2=left, 3=right) |
| `/live/view/show_clip_envelope` | | | Focus Clip View and show the Envelopes box for the clip displayed there |
| `/live/view/hide_clip_envelope` | | | Hide it again |
| `/live/view/nudge_clip_transposition` | semitones | new_value | Add `semitones` to the displayed clip's `pitch_coarse`, clamped to -48..48 |
| `/live/view/set_clip_transposition` | semitones | new_value | Set it absolutely, same clamp |

Why the clip four: the Envelopes box tab isn't reachable through the Live API, and transposition
can otherwise only be addressed per track/clip index, never "whatever clip the user is looking at".
All four act on `song.view.detail_clip` and raise `RuntimeError` when nothing is shown there; the
transposition pair also raise for non-audio clips.

**Tests** in `tests/test_view.py`, following the existing conventions:

- `test_scroll_view_smoke` — as before
- `test_view_clip_envelope_show_hide` — show/hide return nothing, so like `scroll_view` the
  assertion is that the handler chain still answers afterwards
- `test_view_set_clip_transposition` — checks the reply *and* cross-checks
  `/live/clip/get/pitch_coarse`, so it tests the write rather than just the return value
- `test_view_set_clip_transposition_clamps` — `100 → 48`, `-100 → -48`
- `test_view_nudge_clip_transposition` — accumulates `+12, +12, -24` and clamps at 48

A module-scoped `_clips` fixture creates its own MIDI clip and records a short audio clip (the
transposition pair need an audio clip), then deletes both — same shape as `test_clip.py`'s fixture.

**Now actually run** against Live 12.4.2 — `8 passed` for the whole file. Running it for the
first time turned up three things worth noting, only one of which was in the new tests:

- `show_clip_envelope` checked `detail_clip` *before* focusing Clip View, so with the detail pane
  on Device View it refused to do the very thing that would have made a clip available. Focus
  first, then check.
- The fixture created a MIDI clip nothing used, which meant it needed a MIDI track at a fixed
  index; on a set whose first tracks are all audio, Live answers *"MIDI clips can only be created
  on MIDI tracks"* and the fixture falls over. It now records only the audio clip the transposition
  tests need.
- `test_scroll_view_smoke` left the selection wherever scrolling put it. On a set with return
  tracks that can be somewhere `/live/view/get/selected_clip` cannot express (it looks the selected
  track up in `song.tracks`), which failed every later selection-reading test — including the
  pre-existing `test_selected_clip`. It restores the selection now.

The transposition queries also carry an explicit timeout: they answer in ~85–90ms, close enough to
`client.query`'s one-tick default to race.

218 insertions, 2 deletions, 3 files.
